### PR TITLE
Add python-graphviz to docs deps

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -42,6 +42,7 @@ format = "ruff format ."
 
 [feature.docs.dependencies]
 pandoc = "*"
+python-graphviz = "*"
 
 # Per-package docs features (install with docs extra)
 [feature.docs-essreduce.pypi-dependencies]


### PR DESCRIPTION
Fixes errors when trying to render workflow graphs in docs
<img width="1021" height="200" alt="Screenshot_20260309_163322" src="https://github.com/user-attachments/assets/1525e04e-da71-4c4d-978b-b5b9bf83fcbb" />
