### PR TITLE
No cancel of the job on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
When we merge stuff in the main branch, we probably shouldn't cancel the concurrent jobs.
For example, when I merged `essnmx` merge PR, #171 the CI failed because I merged #187 soon after and the concurrency check stopped the CI action triggered by #171 : https://github.com/scipp/ess/actions/runs/22944543710/job/66593620907

But the CI action triggered by #187  didn't run the test on the packages because it was update only in the markdown and we have file filter.

I think we should either trigger all tests any main branch update, or remove the concurrency cancel rule for the main branch.

I prefer removing the concurrency cancellation rule so I'm proposing this change.