### PR TITLE
[Essimaging]: Do not allow nbsphinx errors in docs builds

### DIFF
--- a/packages/essimaging/docs/conf.py
+++ b/packages/essimaging/docs/conf.py
@@ -46,8 +46,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-nbsphinx_allow_errors = True
-
 myst_enable_extensions = [
     "amsmath",
     "colon_fence",

--- a/packages/essimaging/src/ess/imaging/types.py
+++ b/packages/essimaging/src/ess/imaging/types.py
@@ -26,6 +26,7 @@ TofDetector = tof_t.TofDetector
 PulseStrideOffset = tof_t.PulseStrideOffset
 TimeOfFlightLookupTable = tof_t.TimeOfFlightLookupTable
 TimeOfFlightLookupTableFilename = tof_t.TimeOfFlightLookupTableFilename
+LookupTableRelativeErrorThreshold = tof_t.LookupTableRelativeErrorThreshold
 
 UncertaintyBroadcastMode = _UncertaintyBroadcastMode
 

--- a/packages/essimaging/src/ess/odin/workflows.py
+++ b/packages/essimaging/src/ess/odin/workflows.py
@@ -14,6 +14,7 @@ from ..imaging.types import (
     BeamMonitor3,
     BeamMonitor4,
     DarkBackgroundRun,
+    LookupTableRelativeErrorThreshold,
     NeXusMonitorName,
     OpenBeamRun,
     PulseStrideOffset,
@@ -29,6 +30,13 @@ def default_parameters() -> dict:
         NeXusMonitorName[BeamMonitor3]: "beam_monitor_3",
         NeXusMonitorName[BeamMonitor4]: "beam_monitor_4",
         PulseStrideOffset: None,
+        LookupTableRelativeErrorThreshold: {
+            "event_mode_detectors/timepix3": float('inf'),
+            "beam_monitor_1": float('inf'),
+            "beam_monitor_2": float('inf'),
+            "beam_monitor_3": float('inf'),
+            "beam_monitor_4": float('inf'),
+        },
     }
 
 

--- a/packages/essimaging/src/ess/tbl/workflow.py
+++ b/packages/essimaging/src/ess/tbl/workflow.py
@@ -10,6 +10,7 @@ from ess.reduce.time_of_flight.workflow import GenericTofWorkflow
 from ..imaging.conversion import providers as conversion_providers
 from ..imaging.types import (
     BeamMonitor1,
+    LookupTableRelativeErrorThreshold,
     NeXusMonitorName,
     PulseStrideOffset,
     SampleRun,
@@ -20,6 +21,13 @@ def default_parameters() -> dict:
     return {
         NeXusMonitorName[BeamMonitor1]: "monitor_1",
         PulseStrideOffset: None,
+        LookupTableRelativeErrorThreshold: {
+            "timepix3_detector": float('inf'),
+            "ngem_detector": float('inf'),
+            "he3_detector_bank0": float('inf'),
+            "he3_detector_bank1": float('inf'),
+            "monitor_1": float('inf'),
+        },
     }
 
 

--- a/packages/essimaging/tests/odin/data_reduction_test.py
+++ b/packages/essimaging/tests/odin/data_reduction_test.py
@@ -3,7 +3,6 @@
 
 import pytest
 import sciline as sl
-from ess.reduce.time_of_flight import LookupTableRelativeErrorThreshold
 
 import ess.odin.data  # noqa: F401
 from ess import odin
@@ -30,9 +29,6 @@ def workflow() -> sl.Pipeline:
     wf[Filename[OpenBeamRun]] = odin.data.iron_simulation_ob_small()
     wf[NeXusDetectorName] = "event_mode_detectors/timepix3"
     wf[TimeOfFlightLookupTableFilename] = odin.data.odin_tof_lookup_table()
-    wf[LookupTableRelativeErrorThreshold] = {
-        "event_mode_detectors/timepix3": float('inf')
-    }
     # Cache the lookup table
     wf[TimeOfFlightLookupTable] = wf.compute(TimeOfFlightLookupTable)
     return wf

--- a/packages/essimaging/tests/tbl/data_reduction_test.py
+++ b/packages/essimaging/tests/tbl/data_reduction_test.py
@@ -48,11 +48,6 @@ def workflow() -> sl.Pipeline:
     wf = tbl.TblWorkflow()
     wf[Filename[SampleRun]] = tbl.data.tutorial_sample_data()
     wf[TimeOfFlightLookupTableFilename] = tbl.data.tbl_tof_lookup_table_no_choppers()
-    wf[time_of_flight.LookupTableRelativeErrorThreshold] = {
-        "ngem_detector": float('inf'),
-        "he3_detector_bank0": float('inf'),
-        "he3_detector_bank1": float('inf'),
-    }
     return wf
 
 


### PR DESCRIPTION
For some reason, we had `nbsphinx_allow_errors = True` enabled in the docs sphinx config.

**Note more changes here:** we set the `LookupTableRelativeErrorThreshold` to a default value of `Inf` in Odin and TBL workflows, to avoid breaking all existing notebooks.