### PR TITLE
[Essimaging] Remove old luts from odin and tbl data

### DIFF
--- a/packages/essimaging/src/ess/odin/data.py
+++ b/packages/essimaging/src/ess/odin/data.py
@@ -14,8 +14,6 @@ _registry = make_registry(
         "iron_simulation_ob_small.nxs": "md5:7591ed8f0adec2658fb08190bd530b12",
         "iron_simulation_sample_large.nxs": "md5:c162b6abeccb51984880d8d5002bae95",
         "iron_simulation_sample_small.nxs": "md5:dda6fb30aa88780c5a3d4cef6ea05278",
-        "ODIN-tof-lookup-table.h5": "md5:e657021f4508f167b2a2eb550853b06b",
-        "ODIN-tof-lookup-table-5m-65m.h5": "md5:c815eed6835a98d0b8d5252ffe250964",
         "ODIN-wavelength-lookup-table-5m-65m.h5": "md5:44eef2a2e826cec688aeb1b985eb9f9e",  # noqa: E501
     },
 )
@@ -59,18 +57,6 @@ def iron_simulation_ob_large() -> pathlib.Path:
     10M events from the McStas results.
     """
     return _registry.get_path("iron_simulation_ob_large.nxs")
-
-
-def odin_tof_lookup_table() -> pathlib.Path:
-    """
-    Odin TOF lookup table.
-    This file is used to convert the raw ``event_time_offset`` to time-of-flight.
-
-    This table was computed using `Create a time-of-flight lookup table for ODIN
-    <../../odin/odin-make-tof-lookup-table.rst>`_
-    with ``NumberOfSimulatedNeutrons = 5_000_000``.
-    """
-    return _registry.get_path("ODIN-tof-lookup-table-5m-65m.h5")
 
 
 def odin_wavelength_lookup_table() -> pathlib.Path:

--- a/packages/essimaging/src/ess/tbl/data.py
+++ b/packages/essimaging/src/ess/tbl/data.py
@@ -11,8 +11,6 @@ _registry = make_registry(
     version="2",
     files={
         "tbl_sample_data_2025-03.hdf": "md5:12db6bc06721278b3abe47992eac3e77",
-        "TBL-tof-lookup-table-no-choppers.h5": "md5:8bc98fac0ee64fc8f5decf509c75bafe",
-        "TBL-tof-lookup-table-no-choppers-5m-35m.h5": "md5:be7e73f32d395abd3c28b95f75934d61",  # noqa: E501
         "TBL-wavelength-lookup-table-no-choppers-5m-35m.h5": "md5:e28793b7e1c12986ee63a1df68723268",  # noqa: E501
         'tbl-orca-focussing.hdf.zip': Entry(
             alg='md5', chk='f365acd9ea45dd205c0b9398d163cfa4', unzip=True
@@ -27,18 +25,6 @@ _registry = make_registry(
 def tutorial_sample_data() -> pathlib.Path:
     """ """
     return _registry.get_path("tbl_sample_data_2025-03.hdf")
-
-
-def tbl_tof_lookup_table_no_choppers() -> pathlib.Path:
-    """
-    TBL TOF lookup table without choppers.
-    This file is used to convert the neutron arrival time to time-of-flight.
-
-    This table was computed using `Create a time-of-flight lookup table for TBL
-    <../../tbl/tbl-make-tof-lookup-table.rst>`_
-    with ``NumberOfSimulatedNeutrons = 5_000_000``.
-    """
-    return _registry.get_path("TBL-tof-lookup-table-no-choppers-5m-35m.h5")
 
 
 def tbl_wavelength_lookup_table_no_choppers() -> pathlib.Path:


### PR DESCRIPTION
Remove old luts from data registries of odin and tbl as they can no longer be used with the workflows.

See https://github.com/scipp/essdiffraction/pull/259#discussion_r2980403472