### PR TITLE
Update GitHub Actions to use newer action versions and skip job status report on main branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -104,7 +104,7 @@ jobs:
           environments: docs-${{ matrix.package }}
       - name: Build docs
         run: pixi run docs-${{ matrix.package }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:
           name: docs-${{ matrix.package }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
   report:
     name: Report Job Status
     needs: [changes, formatting, test, docs]
-    if: always()
+    if: always() && ( github.ref != 'refs/heads/main' )  # This job is for branch protection rule so it doesn't have to run on main branch.
     runs-on: ubuntu-24.04
     steps:
       - name: Report Job Success

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           branch: gh-pages
           folder: gh-pages-site
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: docs-${{ inputs.package }}
           path: packages/${{ inputs.package }}/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Copy LICENSE into package
         run: cp LICENSE packages/${{ needs.determine-package.outputs.package }}/LICENSE
       - name: Build package
         run: pip install build && python -m build packages/${{ needs.determine-package.outputs.package }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: packages/${{ needs.determine-package.outputs.package }}/dist/
@@ -49,7 +49,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -88,7 +88,7 @@ jobs:
         with:
           branch: gh-pages
           folder: gh-pages-site
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: docs_html
           path: packages/${{ needs.determine-package.outputs.package }}/html
@@ -100,7 +100,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: docs_html
           path: docs_html


### PR DESCRIPTION
I updated the actions that triggered Nodejs 20 deprecation warnings.

And then I realized that we don't need to run the job status report on the main branch so I added the condition.