### PR TITLE
Update old URLs links and update github pages URL schema

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -41,10 +41,11 @@ jobs:
         if: ${{ inputs.publish }}
         run: |
           PACKAGE=${{ inputs.package }}
+          SUBPATH=${PACKAGE#ess}
           git fetch origin gh-pages:gh-pages || true
           git worktree add gh-pages-site gh-pages || mkdir -p gh-pages-site
-          rm -rf gh-pages-site/$PACKAGE
-          cp -r packages/$PACKAGE/html gh-pages-site/$PACKAGE
+          rm -rf gh-pages-site/$SUBPATH
+          cp -r packages/$PACKAGE/html gh-pages-site/$SUBPATH
           cp docs/index.html gh-pages-site/index.html
           touch gh-pages-site/.nojekyll
       - name: Build search index

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,13 +153,17 @@
 
     <div class="label">Packages</div>
     <div class="cards">
-      <a class="card" href="essreduce/">
+      <a class="card" href="reduce/">
         <div class="card-name">essreduce</div>
         <p>Common data reduction tools for the ESS facility</p>
       </a>
-      <a class="card" href="essimaging/">
+      <a class="card" href="imaging/">
         <div class="card-name">essimaging</div>
         <p>Neutron imaging data reduction (ODIN, TBL, YMIR)</p>
+      </a>
+      <a class="card" href="nmx/">
+        <div class="card-name">essnmx</div>
+        <p>Macromolecular crystallography data reduction (NMX)</p>
       </a>
     </div>
   </main>

--- a/packages/essimaging/docs/_templates/doc_version.html
+++ b/packages/essimaging/docs/_templates/doc_version.html
@@ -1,2 +1,2 @@
 <!-- This will display the version of the docs -->
-Current ESSimaging version: {{ version }} (<a href="https://github.com/scipp/essimaging/releases">older versions</a>).
+Current ESSimaging version: {{ version }} (<a href="https://github.com/scipp/ess/releases?q=essimaging">older versions</a>).

--- a/packages/essimaging/docs/about/index.md
+++ b/packages/essimaging/docs/about/index.md
@@ -18,9 +18,9 @@ To cite a specific version of ESSimaging, select the desired version on Zenodo t
 
 ## Older versions of the documentation
 
-Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/essimaging/releases).
+Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/ess/releases?q=essimaging).
 Simply download the archive, unzip and view locally in a web browser.
 
 ## Source code and development
 
-ESSimaging is hosted and developed [on GitHub](https://github.com/scipp/essimaging).
+ESSimaging is hosted and developed [on GitHub](https://github.com/scipp/ess/tree/main/packages/essimaging).

--- a/packages/essimaging/docs/conf.py
+++ b/packages/essimaging/docs/conf.py
@@ -166,7 +166,7 @@ html_theme_options = {
         "image_dark": "_static/logo-dark.svg",
     },
     "external_links": [
-        {"name": "Essreduce", "url": "https://scipp.github.io/essreduce"},
+        {"name": "Essreduce", "url": "https://scipp.github.io/ess/reduce"},
         {"name": "Plopp", "url": "https://scipp.github.io/plopp"},
         {"name": "Sciline", "url": "https://scipp.github.io/sciline"},
         {"name": "Scipp", "url": "https://scipp.github.io"},
@@ -178,7 +178,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/scipp/essimaging",
+            "url": "https://github.com/scipp/ess/tree/main/packages/essimaging",
             "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },

--- a/packages/essimaging/docs/index.md
+++ b/packages/essimaging/docs/index.md
@@ -70,8 +70,8 @@ conda install -c conda-forge essimaging
 
 ## Get in touch
 
-- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/essimaging/discussions). Please include a self-contained reproducible example if possible.
-- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/essimaging).
+- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/ess/discussions). Please include a self-contained reproducible example if possible.
+- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/ess/tree/main/packages/essimaging).
 
 ```{toctree}
 ---

--- a/packages/essimaging/pyproject.toml
+++ b/packages/essimaging/pyproject.toml
@@ -67,7 +67,7 @@ docs = [
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scipp/ess/issues"
-"Documentation" = "https://scipp.github.io/essimaging"
+"Documentation" = "https://scipp.github.io/ess/imaging"
 "Source" = "https://github.com/scipp/ess/tree/main/packages/essimaging"
 
 [tool.setuptools_scm]

--- a/packages/essnmx/docs/_templates/doc_version.html
+++ b/packages/essnmx/docs/_templates/doc_version.html
@@ -1,2 +1,2 @@
 <!-- This will display the version of the docs -->
-Current ESSnmx version: {{ version }} (<a href="https://github.com/scipp/essnmx/releases">older versions</a>).
+Current ESSnmx version: {{ version }} (<a href="https://github.com/scipp/ess/releases?q=essnmx">older versions</a>).

--- a/packages/essnmx/docs/about/data_workflow_overview.md
+++ b/packages/essnmx/docs/about/data_workflow_overview.md
@@ -13,7 +13,7 @@ The main scientific driver is to locate the hydrogen atoms relevant to the funct
 
 ### From single event data to binned image-like data (scipp)
 The first step in the data reduction is to reduce the data from single event data to image-like data. <br>
-Therefore the [essNMX](https://github.com/scipp/essnmx) package is used.
+Therefore the [essNMX](https://github.com/scipp/ess/tree/main/packages/essnmx) package is used.
 
 The time of arrival (TOA) should be converted into time of flight (TOF).
 <!--Not implemented for measurement data-->

--- a/packages/essnmx/docs/about/index.md
+++ b/packages/essnmx/docs/about/index.md
@@ -26,9 +26,9 @@ To cite a specific version of ESSnmx, select the desired version on Zenodo to ge
 
 ## Older versions of the documentation
 
-Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/essnmx/releases).
+Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/ess/releases?q=essnmx).
 Simply download the archive, unzip and view locally in a web browser.
 
 ## Source code and development
 
-ESSnmx is hosted and developed [on GitHub](https://github.com/scipp/essnmx).
+ESSnmx is hosted and developed [on GitHub](https://github.com/scipp/ess/tree/main/packages/essnmx).

--- a/packages/essnmx/docs/conf.py
+++ b/packages/essnmx/docs/conf.py
@@ -167,6 +167,7 @@ html_theme_options = {
         "image_dark": "_static/logo-dark.svg",
     },
     "external_links": [
+        {"name": "Essreduce", "url": "https://scipp.github.io/ess/reduce"},
         {"name": "Plopp", "url": "https://scipp.github.io/plopp"},
         {"name": "Sciline", "url": "https://scipp.github.io/sciline"},
         {"name": "Scipp", "url": "https://scipp.github.io"},
@@ -175,7 +176,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/scipp/essnmx",
+            "url": "https://github.com/scipp/ess/tree/main/packages/essnmx",
             "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },

--- a/packages/essnmx/docs/index.md
+++ b/packages/essnmx/docs/index.md
@@ -34,8 +34,8 @@
 
 ## Get in touch
 
-- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/essnmx/discussions). Please include a self-contained reproducible example if possible.
-- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/essnmx).
+- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/ess/discussions). Please include a self-contained reproducible example if possible.
+- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/ess/tree/main/packages/essnmx).
 
 ```{toctree}
 ---

--- a/packages/essnmx/pyproject.toml
+++ b/packages/essnmx/pyproject.toml
@@ -74,9 +74,9 @@ docs = [
 ]
 
 [project.urls]
-"Bug Tracker" = "https://github.com/scipp/essnmx/issues"
-"Documentation" = "https://scipp.github.io/essnmx"
-"Source" = "https://github.com/scipp/essnmx"
+"Bug Tracker" = "https://github.com/scipp/ess/issues"
+"Documentation" = "https://scipp.github.io/ess/nmx"
+"Source" = "https://github.com/scipp/ess/tree/main/packages/essnmx"
 
 [tool.setuptools_scm]
 root = "../.."

--- a/packages/essreduce/docs/_templates/doc_version.html
+++ b/packages/essreduce/docs/_templates/doc_version.html
@@ -1,2 +1,2 @@
 <!-- This will display the version of the docs -->
-Current ESSreduce version: {{ version }} (<a href="https://github.com/scipp/essreduce/releases">older versions</a>).
+Current ESSreduce version: {{ version }} (<a href="https://github.com/scipp/ess/releases?q=essreduce">older versions</a>).

--- a/packages/essreduce/docs/about/index.md
+++ b/packages/essreduce/docs/about/index.md
@@ -18,9 +18,9 @@ To cite a specific version of ESSreduce, select the desired version on Zenodo to
 
 ## Older versions of the documentation
 
-Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/essreduce/releases).
+Older versions of the documentation pages can be found under the assets of each [release](https://github.com/scipp/ess/releases?q=essreduce).
 Simply download the archive, unzip and view locally in a web browser.
 
 ## Source code and development
 
-ESSreduce is hosted and developed [on GitHub](https://github.com/scipp/essreduce).
+ESSreduce is hosted and developed [on GitHub](https://github.com/scipp/ess/tree/main/packages/essreduce).

--- a/packages/essreduce/docs/conf.py
+++ b/packages/essreduce/docs/conf.py
@@ -168,8 +168,8 @@ html_theme_options = {
     },
     "external_links": [
         {"name": "ESSdiffraction", "url": "https://scipp.github.io/essdiffraction"},
-        {"name": "ESSimaging", "url": "https://scipp.github.io/essimaging"},
-        {"name": "ESSnmx", "url": "https://scipp.github.io/essnmx"},
+        {"name": "ESSimaging", "url": "https://scipp.github.io/ess/imaging"},
+        {"name": "ESSnmx", "url": "https://scipp.github.io/ess/nmx"},
         {"name": "ESSpolarization", "url": "https://scipp.github.io/esspolarization"},
         {"name": "ESSreflectometry", "url": "https://scipp.github.io/essreflectometry"},
         {"name": "ESSsans", "url": "https://scipp.github.io/esssans"},
@@ -178,7 +178,7 @@ html_theme_options = {
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/scipp/essreduce",
+            "url": "https://github.com/scipp/ess/tree/main/packages/essreduce",
             "icon": "fa-brands fa-github",
             "type": "fontawesome",
         },

--- a/packages/essreduce/docs/index.md
+++ b/packages/essreduce/docs/index.md
@@ -34,8 +34,8 @@
 
 ## Get in touch
 
-- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/essreduce/discussions). Please include a self-contained reproducible example if possible.
-- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/essreduce).
+- If you have questions that are not answered by these documentation pages, ask on [discussions](https://github.com/scipp/ess/discussions). Please include a self-contained reproducible example if possible.
+- Report bugs (including unclear, missing, or wrong documentation!), suggest features or view the source code [on GitHub](https://github.com/scipp/ess/tree/main/packages/essreduce).
 
 ```{toctree}
 ---

--- a/packages/essreduce/pyproject.toml
+++ b/packages/essreduce/pyproject.toml
@@ -70,7 +70,7 @@ grow-nexus = "ess.reduce.scripts.grow_nexus:main"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/scipp/ess/issues"
-"Documentation" = "https://scipp.github.io/essreduce"
+"Documentation" = "https://scipp.github.io/ess/reduce"
 "Source" = "https://github.com/scipp/ess/tree/main/packages/essreduce"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This rewrites the docs urls to `scipp.github.io/ess/{technique}` from `scipp.github.io/ess/ess{technique}`

This should also fix https://github.com/scipp/ess/issues/181

