### PR TITLE
Require OSX 14 in pixi

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,10 @@ version = "2026.2.0"
 [dependencies]
 python = "3.11.*"
 
+[system-requirements]
+# Scipp does not support older OSX versions.
+macos = "14.0"
+
 # ==================== Parameterized tasks ====================
 
 [tasks.test]


### PR DESCRIPTION
Pixi cannot solve environments with Scipp >=26 from conda-forge because of https://github.com/scipp/scipp/pull/3829. Installing from PyPI should be fine. See https://github.com/scipp/scipp/issues/3887