### PR TITLE
[ESSSANS] Improve esssans ci runtime

### DIFF
--- a/packages/esssans/docs/user-guide/common/beam-center-finder.ipynb
+++ b/packages/esssans/docs/user-guide/common/beam-center-finder.ipynb
@@ -641,6 +641,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.14"
+  },
+  "nbsphinx": {
+   "execute": "never"
   }
  },
  "nbformat": 4,

--- a/packages/esssans/tests/isissans/sans2d_reduction_test.py
+++ b/packages/esssans/tests/isissans/sans2d_reduction_test.py
@@ -214,6 +214,9 @@ def test_beam_center_from_center_of_mass_independent_of_set_beam_center(pipeline
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
 
 
+@pytest.mark.skip(
+    reason="Beam center finder tests are slow and we are revisiting the approach."
+)
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result(pipeline):
     pipeline[DirectBeam] = None
     center = sans.beam_center_finder.beam_center_from_iofq(
@@ -222,6 +225,9 @@ def test_beam_center_finder_without_direct_beam_reproduces_verified_result(pipel
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m'))
 
 
+@pytest.mark.skip(
+    reason="Beam center finder tests are slow and we are revisiting the approach."
+)
 def test_beam_center_can_get_closer_to_verified_result_with_low_counts_mask(pipeline):
     def low_counts_mask(
         sample: RawDetector[SampleRun],
@@ -239,6 +245,9 @@ def test_beam_center_can_get_closer_to_verified_result_with_low_counts_mask(pipe
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(5e-4, unit='m'))
 
 
+@pytest.mark.skip(
+    reason="Beam center finder tests are slow and we are revisiting the approach."
+)
 def test_beam_center_finder_works_with_direct_beam(pipeline):
     q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
     center_with_direct_beam = sans.beam_center_finder.beam_center_from_iofq(
@@ -249,6 +258,9 @@ def test_beam_center_finder_works_with_direct_beam(pipeline):
     )
 
 
+@pytest.mark.skip(
+    reason="Beam center finder tests are slow and we are revisiting the approach."
+)
 def test_beam_center_finder_independent_of_set_beam_center(pipeline):
     pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
     q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
@@ -260,6 +272,9 @@ def test_beam_center_finder_independent_of_set_beam_center(pipeline):
     )
 
 
+@pytest.mark.skip(
+    reason="Beam center finder tests are slow and we are revisiting the approach."
+)
 def test_beam_center_finder_works_with_pixel_dependent_direct_beam(pipeline):
     q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
     center_pixel_independent_direct_beam = (

--- a/packages/esssans/tests/loki/diagnostics_test.py
+++ b/packages/esssans/tests/loki/diagnostics_test.py
@@ -31,24 +31,29 @@ def loki_data():
     return data
 
 
-def test_create_loki_bank_viewer(loki_data):
+@pytest.fixture(scope='module')
+def histogrammed_loki_data(loki_data):
+    return loki_data.hist()
+
+
+def test_create_loki_bank_viewer(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist())
+    viewer = LokiBankViewer(histogrammed_loki_data)
     assert len(viewer.tabs.children) == 9 + 1  # 9 banks + all banks tab
 
 
-def test_loki_bank_viewer_plotting_args(loki_data):
+def test_loki_bank_viewer_plotting_args(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist(), norm='log', cmap='jet')
+    viewer = LokiBankViewer(histogrammed_loki_data, norm='log', cmap='jet')
     for fig in viewer.subplots:
         mapper = fig.view.colormapper
         assert mapper.norm == 'log'
         assert mapper.cmap.name == 'jet'
 
 
-def test_loki_bank_viewer_toggle_log_scale(loki_data):
+def test_loki_bank_viewer_toggle_log_scale(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist())
+    viewer = LokiBankViewer(histogrammed_loki_data)
     for fig in viewer.subplots:
         mapper = fig.view.colormapper
         assert mapper.norm == 'linear'
@@ -58,36 +63,36 @@ def test_loki_bank_viewer_toggle_log_scale(loki_data):
         assert mapper.norm == 'log'
 
 
-def test_loki_bank_viewer_sum_all_layers(loki_data):
+def test_loki_bank_viewer_sum_all_layers(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist())
+    viewer = LokiBankViewer(histogrammed_loki_data)
     old_max = [fig.view.colormapper.vmax for fig in viewer.subplots]
     viewer.layer_sum.value = True
     for i, fig in enumerate(viewer.subplots):
         assert fig.view.colormapper.vmax >= old_max[i]
 
 
-def test_loki_bank_viewer_sum_all_straws(loki_data):
+def test_loki_bank_viewer_sum_all_straws(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist())
+    viewer = LokiBankViewer(histogrammed_loki_data)
     old_max = [fig.view.colormapper.vmax for fig in viewer.subplots]
     viewer.straw_sum.value = True
     for i, fig in enumerate(viewer.subplots):
         assert fig.view.colormapper.vmax >= old_max[i]
 
 
-def test_loki_bank_viewer_change_bank(loki_data):
+def test_loki_bank_viewer_change_bank(histogrammed_loki_data):
     matplotlib.use('module://ipympl.backend_nbagg')
-    viewer = LokiBankViewer(loki_data.hist())
+    viewer = LokiBankViewer(histogrammed_loki_data)
     # For now, just check no error occurs when changing tab
     viewer.tabs.selected_index = 2
     # Change back to all banks
     viewer.tabs.selected_index = 0
 
 
-def test_creat_loki_instrument_view(loki_data):
-    InstrumentView(loki_data.hist())
+def test_creat_loki_instrument_view(histogrammed_loki_data):
+    InstrumentView(histogrammed_loki_data)
 
 
 def test_creat_loki_instrument_view_with_dim_slider(loki_data):
-    InstrumentView(loki_data.hist(event_time_offset=200), dim='event_time_offset')
+    InstrumentView(loki_data.hist(event_time_offset=10), dim='event_time_offset')


### PR DESCRIPTION
- Skip beam_center_finder tests which do not use the center of mass method
- Refactor fixtures in diagnostics tests to use less memory
- Exclude beam center finder notebook from execution in the docs

Build times:

- Tests: 16min --> 7min
- Docs: 8min --> 6min