### PR TITLE
Do not run CI when merging to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
             essimaging:
@@ -38,7 +38,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
             essnmx:
@@ -47,7 +47,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
             essreflectometry:
@@ -56,7 +56,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
             essdiffraction:
@@ -65,7 +65,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
             esssans:
@@ -74,7 +74,7 @@ jobs:
               - 'pyproject.toml'
               - 'pixi.lock'
               - 'pixi.toml'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
               - '.pre-commit-config.yaml'
               - '.python-version'
 
@@ -140,7 +140,7 @@ jobs:
   report:
     name: Report Job Status
     needs: [changes, formatting, test, docs]
-    if: always()
+    if: always()  # Should always run regardless of the state of the needs jobs.
     runs-on: ubuntu-24.04
     steps:
       - name: Report Job Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
   merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -142,7 +140,7 @@ jobs:
   report:
     name: Report Job Status
     needs: [changes, formatting, test, docs]
-    if: always() && ( github.ref != 'refs/heads/main' )  # This job is for branch protection rule so it doesn't have to run on main branch.
+    if: always()
     runs-on: ubuntu-24.04
     steps:
       - name: Report Job Success


### PR DESCRIPTION
Do we really need to run the CI again when we merge into `main`?

The tests have already run in the PRs.
Requiring branches to be up to date with `main` or using the merge queue should make sure we dont merge stuff that is out of date…
It would save quite a lot of CI jobs?