### PR TITLE
[CI] Add PR title and label bot.

### DIFF
--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -77,8 +77,9 @@ jobs:
         if: ${{ steps.new-labels.outputs.new_labels }}
         run: |
           echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
-          echo "It looks like you're working on these packages/features: ${new_labels}" >> pr-comment.md;
-          gh pr comment ${PR_NUM} -F pr-comment.md;
+          echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
+          echo "These labels were missing: ${new_labels}" >> pr-comment.md;
+          gh pr comment ${PR_NUM} --edit-last --create-if-none -F pr-comment.md;
       - id: export-comment
         if: ${{ steps.new-labels.outputs.new_labels }}
         uses: actions/upload-artifact@v7
@@ -107,7 +108,7 @@ jobs:
         with:
           path: ./
           name: pr-comment.md
-      - run: if [[ -f pr-commit.md ]]; then echo "" >> pre-comment.md; echo "Found existing pr-comment file."; cat pr-comment.md; fi
+      - run: if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; echo "Found existing pr-comment file."; cat pr-comment.md; else echo "Hi!" >> pre-comment.md; fi
       - id: title-prefix
         name: Compose title prefix.
         run: |

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -131,7 +131,7 @@ jobs:
         id: new-title-add-to-report
         if: ${{ needs.check-pr.outputs.new_title }}
         run: |
-          if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi
+          if [[ -f pr-comment.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi
           echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
       - name: Leave a comment about the changes.

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -118,9 +118,7 @@ jobs:
         id: new-labels-add-to-report
         if: ${{ needs.check-pr.outputs.new_labels }}
         run: |
-          echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
-          echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
-          echo "These labels were missing: ${new_labels}" >> pr-comment.md;
+          echo "Hi! Your PR was missing some labels 🔖 so I added them: ${new_labels}" >> pr-comment.md;
       - name: Add missing title prefix to the PR
         id: edit-title-prefix
         if: ${{ needs.check-pr.outputs.new_title }}
@@ -131,9 +129,8 @@ jobs:
         id: new-title-add-to-report
         if: ${{ needs.check-pr.outputs.new_title }}
         run: |
-          if [[ -f pr-comment.md ]]; then echo "\nHi Again!" >> pr-comment.md; else echo "Hi!" >> pr-comment.md; fi
-          echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
-          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
+          if [[ -f pr-comment.md ]]; then greeting="Hi Again 👋!"; else greeting="Hi 👋!"; fi
+          echo "${greeting} I added the missing prefix: ${title_prefix} to the title." >> pr-comment.md;
       - name: Leave a comment about the changes.
         id: report
         run: gh pr comment ${PR_NUM} -F pr-comment.md;

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -88,7 +88,7 @@ jobs:
 
   edit-pr:
     name: Edit PR with New Labels or Title Prefix and Report
-    runs-on: ubuntu-slim-24.04
+    runs-on: ubuntu-slim
     needs:
       - check-pr
     env:

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -31,6 +31,8 @@ jobs:
     outputs:
       all_labels: ${{ steps.all-labels.outputs.all_labels }}
       new_labels: ${{ steps.new-labels.outputs.new_labels }}
+      title_prefix: ${{ steps.title-check.outputs.title_prefix }}
+      new_title: ${{ steps.title-check.outputs.new_title }}
     if: ${{ github.event.action == 'opened' || github.event.action == 'closed' || github.event.action == 'reopened' }}
     steps:
       - uses: actions/checkout@v6
@@ -54,7 +56,6 @@ jobs:
         name: Collect labels that need to be added among all_labels.
         env:
            all_labels: ${{ steps.all-labels.outputs.all_labels }}
-           GH_TOKEN: ${{ github.token }}
         run: |
           EXISTING_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}';
           new_labels=();
@@ -67,6 +68,22 @@ jobs:
             fi
           done
           echo "new_labels=${new_labels[@]}" >> "$GITHUB_OUTPUT";
+      - id: title-check
+        name: Check the title prefix.
+        env:
+          all_labels: ${{ steps.all-labels.outputs.all_labels }}
+          new_labels: ${{ steps.new-labels.outputs.new_labels }}
+        run: |
+          labels=(${all_labels});
+          # Only one label
+          if [[ ${#labels[@]} -eq 1  ]]; then
+            title_prefix="[${labels[0]^^}]";
+            echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
+            echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
+          # Ignore multiple labels
+          elif [[ ${#labels[@]} -gt 1  ]]; then
+            echo "There are multiple labels found for this PR. Skipping making a new title...";
+          fi
 
   check-pr-title:
     name: Title Prefix
@@ -91,110 +108,60 @@ jobs:
           labels=(${all_labels});
           # Only one label
           if [[ ${#labels[@]} -eq 1  ]]; then
-            label=${labels[0]};
-            # Do not drop ess prefix if it's essreduce... cause... just reduce doesn't make sense...
-            if [[ "${label}" == "essreduce" ]]; then
-              title_prefix="[${label}]";
-            # Only use technique part for prefix
-            elif [[ "${label}" =~ ^ess([a-zA-Z]+)$ ]]; then
-              title_prefix="[${BASH_REMATCH[1]}]";
-            else
-              title_prefix="[${label}]";
-            fi
-            title_prefix=${title_prefix^^};
-          # Handle multiple labels
+            title_prefix="[${labels[0]^^}]";
+            echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
+            echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
+          # Ignore multiple labels
           elif [[ ${#labels[@]} -gt 1  ]]; then
-            ess_labels=();
-            other_labels=();
-            label_to_title=();
-            for label in ${labels[@]}; do
-              # Do not drop ess prefix if it's essreduce... cause... just reduce doesn't make sense...
-              if [[ "${label}" == "essreduce" ]]; then
-                ess_labels+=(${label});
-              # Only use technique part for prefix
-              elif [[ "${label}" =~ ^ess([a-zA-Z]+)$ ]]; then
-              	ess_labels+=(${BASH_REMATCH[1]});
-              else
-                other_labels+=(${label});
-              fi
-            done
-            # Collect only ess titles
-            ess_title_prefixes=()
-            if [[ ${#ess_labels[@]} -eq 1 ]]; then
-              ess_title_prefixes+=(${ess_labels[0]});
-            elif [[ ${#ess_labels[@]} -gt 1 ]]; then
-              ess_title_prefixes+=('ess');
-            fi
-            # Combine all title prefixes
-            label_to_title=(${ess_title_prefixes[@]} ${other_labels[@]});
-            # Capitalize title prefixes
-            title_prefixes=();
-            for title in ${label_to_title[@]}; do
-              title_prefixes+=(${title^^});
-            done
-            title_prefix="[${title_prefixes[@]}]";
+            echo "There are multiple labels found for this PR. Skipping making a new title...";
           fi
-          echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
-          echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
-      - id: title-prefix-correct
-        name: Title already has correct prefix.
-        if: ${{ startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) }}
-        run: echo "Title already has prefix ${title_prefix}."
-      - id: report-title-prefix-unexpected
-        name: Title already has prefix but not expected one.
-        if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && startsWith( env.original_title, '[' ) }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "Title already has prefix but not same as the expected one. Reporting in the comment...";
-          echo "Your PR has unexpected title. Recommended prefix is: ${title_prefix}." >> pr-comment.md;
-          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
-          gh pr comment ${PR_NUM} \
-            --edit-last \
-            --create-if-none \
-            -F pr-comment.md;
-      - id: report-title-prefix-none
-        name: Add title prefix.
-        if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && !startsWith( env.original_title, '[' ) }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
-        run: |
-          echo "Title doesn't have expected prefix... adding one...";
-          gh pr edit ${PR_NUM} --title "${title_prefix} ${original_title}";
-          echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
-          echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
-          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
-          gh pr comment ${PR_NUM} \
-            --edit-last \
-            --create-if-none \
-            -F pr-comment.md;
 
   edit-pr:
-    name: Edit and Report New Labels or Title Prefix
+    name: Edit PR with New Labels or Title Prefix and Report
     runs-on: ubuntu-slim-24.04
+    needs:
+      - check-pr-labels
+      - check-pr-title
     env:
        all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
        new_labels: ${{ needs.check-pr-labels.outputs.new_labels }}
+       title_prefix: ${{ needs.check-pr-title.outputs.title_prefix }}
+       new_title: ${{ needs.check-pr-title.outputs.new_title }}
+       # The bot needs this token for editting PR.
        GH_TOKEN: ${{ github.token }}
     permissions:
       # The bot write comments, add labels or update the title of PR.
       pull-requests: write
-    needs:
-      - check-pr-labels
-    if: ${{ needs.check-pr-labels.outputs.new_labels }}
+    # If there is any new label or new title
+    if: ${{ needs.check-pr-labels.outputs.new_labels || needs.check-pr-title.outputs.new_title }}
     steps:
-      - id: add-new-labels
+      - name: Add new labels to the PR
+        id: add-new-labels
+        if: ${{ needs.check-pr-labels.outputs.new_labels }}
         run: |
           combined_label=${new_labels[0]};
           for label in ${new_labels[@]:1}; do combined_label="${combined_label},${label}"; done
           gh pr edit ${PR_NUM} --add-label ${combined_label};
-      - id: new-labels-report
+      - name: Collect comments about the new labels
+        id: new-labels-add-to-report
+        if: ${{ needs.check-pr-labels.outputs.new_labels }}
         run: |
           echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
           echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
           echo "These labels were missing: ${new_labels}" >> pr-comment.md;
-          gh pr comment ${PR_NUM} -F pr-comment.md;
-      - id: new-title-report
+      - name: Add missing title prefix to the PR
+        id: edit-title-prefix
+        if: ${{ needs.check-pr-title.outputs.new_title }}
+        run: |
+          echo "Title doesn't have any relevant prefix... adding one...";
+          gh pr edit ${PR_NUM} --title "${new_title}";
+      - name: Collect comments about the new title
+        id: new-title-add-to-report
+        if: ${{ needs.check-pr-title.outputs.new_title }}
         run: |
           if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi
+          echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
+          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
+      - name: Leave a comment about the changes.
+        id: report        
+        run: gh pr comment ${PR_NUM} -F pr-comment.md;

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -170,7 +170,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "Title already has prefix but not same as the expected one. Reporting in the comment...";
-          echo "Hi! Your PR has unexpected title. Recommended prefix is: ${title_prefix}." >> pr-comment.md;
+          echo "Your PR has unexpected title. Recommended prefix is: ${title_prefix}." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
           gh pr comment ${PR_NUM} \
             --edit-last \
@@ -185,7 +185,7 @@ jobs:
         run: |
           echo "Title doesn't have expected prefix... adding one...";
           gh pr edit ${PR_NUM} --title "${title_prefix} ${original_title}";
-          echo "Hi! Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
+          echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
           gh pr comment ${PR_NUM} \
             --edit-last \

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           all_labels: ${{ steps.all-labels.outputs.all_labels }}
           new_labels: ${{ steps.new-labels.outputs.new_labels }}
+          original_title: ${{ github.event.pull_request.title }}
         run: |
           labels=(${all_labels});
           # Only one label

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -79,7 +79,7 @@ jobs:
           echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
           echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
           echo "These labels were missing: ${new_labels}" >> pr-comment.md;
-          gh pr comment ${PR_NUM} --edit-last --create-if-none -F pr-comment.md;
+          gh pr comment ${PR_NUM} -F pr-comment.md;
       - id: export-comment
         if: ${{ steps.new-labels.outputs.new_labels }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -109,8 +109,9 @@ jobs:
         id: add-new-labels
         if: ${{ needs.check-pr.outputs.new_labels }}
         run: |
-          combined_label=${new_labels[0]};
-          for label in ${new_labels[@]:1}; do combined_label="${combined_label},${label}"; done
+          labels=(${new_labels});
+          combined_label=${labels[0]};
+          for label in ${labels[@]:1}; do combined_label="${combined_label},${label}"; done
           gh pr edit ${PR_NUM} --add-label ${combined_label};
       - name: Collect comments about the new labels
         id: new-labels-add-to-report

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: git fetch origin ${{ github.base_ref }}
       - name: Collect all expected labels based on the change.
-        id: all-labels        
+        id: all-labels
         run: |
           DIFFFILES=($(git diff --name-only origin/${{ github.base_ref }}));
           labels=($(for diff_file in ${DIFFFILES[@]}; do
@@ -53,7 +53,7 @@ jobs:
           echo "Found labels to add: ${labels[@]}";
           echo "all_labels=${labels[@]}" >> "$GITHUB_OUTPUT";
       - name: Collect labels that need to be added among all_labels.
-        id: new-labels        
+        id: new-labels
         env:
            all_labels: ${{ steps.all-labels.outputs.all_labels }}
         run: |
@@ -97,7 +97,7 @@ jobs:
        new_labels: ${{ needs.check-pr.outputs.new_labels }}
        title_prefix: ${{ needs.check-pr.outputs.title_prefix }}
        new_title: ${{ needs.check-pr.outputs.new_title }}
-       # The bot needs this token for editting PR.
+       # The bot needs this token for editing PR.
        GH_TOKEN: ${{ github.token }}
     permissions:
       # The bot write comments, add labels or update the title of PR.
@@ -135,5 +135,5 @@ jobs:
           echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
       - name: Leave a comment about the changes.
-        id: report        
+        id: report
         run: gh pr comment ${PR_NUM} -F pr-comment.md;

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -131,7 +131,7 @@ jobs:
         id: new-title-add-to-report
         if: ${{ needs.check-pr.outputs.new_title }}
         run: |
-          if [[ -f pr-comment.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi
+          if [[ -f pr-comment.md ]]; then echo "\nHi Again!" >> pr-comment.md; else echo "Hi!" >> pr-comment.md; fi
           echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
       - name: Leave a comment about the changes.

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -56,6 +56,7 @@ jobs:
       - id: new-labels
         env:
            all_labels: ${{ steps.all-labels.outputs.all_labels }}
+           GH_TOKEN: ${{ github.token }}
         run: |
           EXISTING_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}';
           new_labels=();
@@ -93,7 +94,6 @@ jobs:
       - check-pr-labels
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }} # Only when it's (re)opened.
     env:
-      GH_TOKEN: ${{ github.token }}
       PR_NUM: ${{ github.event.pull_request.number }}
       all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
       original_title: ${{ github.event.pull_request.title }}
@@ -164,6 +164,8 @@ jobs:
       - id: report-title-prefix-unexpected
         name: Title already has prefix but not expected one.
         if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && startsWith( env.original_title, '[' ) }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Title already has prefix but not same as the expected one. Reporting in the comment...";
           echo "Hi! Your PR has unexpected title. Recommended prefix is: ${title_prefix}." >> pr-comment.md;
@@ -176,7 +178,8 @@ jobs:
         name: Add title prefix.
         if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && !startsWith( env.original_title, '[' ) }}
         env:
-           title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
+          GH_TOKEN: ${{ github.token }}
+          title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
         run: |
           echo "Title doesn't have expected prefix... adding one...";
           gh pr edit ${PR_NUM} --title "${title_prefix} ${original_title}";

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -1,0 +1,188 @@
+name: Check PR
+run-name: Check PR(\#${{ github.event.pull_request.number }})
+
+on:
+  pull_request:
+    types:
+      # Label checks should run on `opened`, `reopened` and `closed`
+      # but title check should only run on `opened` or `reopened`.
+      - opened
+      - reopened
+      - closed
+    paths:
+      # Labels are added based on changes of specific path patterns.
+      # Make sure the paths are handled when you add a new path patterns.
+      - 'packages/**'
+      - '.github/**'
+      - 'pixi.toml'
+      - 'docs/**'
+
+concurrency:
+  # Even if the pull request has same reference, it should also run again if it's a different PR.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number }}
+
+permissions:
+  # The bot write comments, add labels or update the title of PR.
+  pull-requests: write
+
+jobs:
+  check-pr-labels:
+    name: Labels
+    runs-on: ubuntu-24.04
+    env:
+      PR_NUM: ${{ github.event.pull_request.number }}
+    outputs:
+      all_labels: ${{ steps.all-labels.outputs.all_labels }}
+      new_labels: ${{ steps.new-labels.outputs.new_labels }}
+    if: ${{ github.event.action == 'opened' || github.event.action == 'closed' || github.event.action == 'reopened' }}
+    steps:
+      - uses: actions/checkout@v6
+      - run: git fetch origin ${{ github.base_ref }}
+      - id: all-labels
+        name: Collect all expected labels based on the change.
+        run: |
+          DIFFFILES=($(git diff --name-only origin/${{ github.base_ref }}));
+          labels=($(for diff_file in ${DIFFFILES[@]}; do
+            if [[ "${diff_file}" =~ ^packages\/([a-zA-Z]+)\/[a-zA-Z]+ ]]; then
+                echo ${BASH_REMATCH[1]};
+              elif [[ ${diff_file} =~ ^\.github* || ${diff_file} == "pixi\.toml" ]]; then
+                echo CI;
+              elif [[ ${diff_file} =~ ^docs\/* ]]; then
+                echo documentation;
+              fi
+            done | sort -u));
+          echo "Found labels to add: ${labels[@]}";
+          echo "all_labels=${labels[@]}" >> "$GITHUB_OUTPUT";
+      - id: new-labels
+        env:
+           all_labels: ${{ steps.all-labels.outputs.all_labels }}
+        run: |
+          EXISTING_LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}';
+          new_labels=();
+          for label in ${all_labels[@]}; do
+            if [[ "$EXISTING_LABELS" == *"${label}"* ]]; then
+          	  echo "${label} is already added to the current PR.";
+            else
+              new_labels+=("${label}");
+          	  gh pr edit ${PR_NUM} --add-label ${label};
+            fi
+          done
+          echo "new_labels=${new_labels[@]}" >> "$GITHUB_OUTPUT";
+      - id: new-labels-report
+        env:
+           all_labels: ${{ steps.all-labels.outputs.all_labels }}
+           new_labels: ${{ steps.new-labels.outputs.new_labels }}
+           GH_TOKEN: ${{ github.token }}
+        if: ${{ steps.new-labels.outputs.new_labels }}
+        run: |
+          echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
+          echo "It looks like you're working on these packages/features: ${new_labels}" >> pr-comment.md;
+          gh pr comment ${PR_NUM} -F pr-comment.md;
+      - id: export-comment
+        if: ${{ steps.new-labels.outputs.new_labels }}
+        uses: actions/upload-artifact@v7
+        with:
+          path: pr-comment.md
+          name: pr-comment.md
+          if-no-files-found: ignore
+
+  check-pr-title:
+    name: Title Prefix
+    runs-on: ubuntu-24.04
+    needs:
+      - check-pr-labels
+    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }} # Only when it's (re)opened.
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+      all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
+      original_title: ${{ github.event.pull_request.title }}
+    outputs:
+      title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: download-comment
+        uses: actions/download-artifact@v8
+        continue-on-error: true  # pre-commit.md might not exist.
+        with:
+          path: ./
+          name: pr-comment.md
+      - run: if [[ -f pr-commit.md ]]; then echo "" >> pre-comment.md; echo "Found existing pr-comment file."; cat pr-comment.md; fi
+      - id: title-prefix
+        name: Compose title prefix.
+        run: |
+          labels=(${all_labels});
+          # Only one label
+          if [[ ${#labels[@]} -eq 1  ]]; then
+            label=${labels[0]};
+            # Do not drop ess prefix if it's essreduce... cause... just reduce doesn't make sense...
+            if [[ "${label}" == "essreduce" ]]; then
+              title_prefix="[${label}]";
+            # Only use technique part for prefix
+            elif [[ "${label}" =~ ^ess([a-zA-Z]+)$ ]]; then
+              title_prefix="[${BASH_REMATCH[1]}]";
+            else
+              title_prefix="[${label}]";
+            fi
+          # Handle ultiple labels
+          elif [[ ${#labels[@]} -gt 1  ]]; then
+            ess_labels=();
+            other_labels=();
+            label_to_title=();
+            for label in ${labels[@]}; do
+              # Do not drop ess prefix if it's essreduce... cause... just reduce doesn't make sense...
+              if [[ "${label}" == "essreduce" ]]; then
+                ess_labels+=(${label});
+              # Only use technique part for prefix
+              elif [[ "${label}" =~ ^ess([a-zA-Z]+)$ ]]; then
+              	ess_labels+=(${BASH_REMATCH[1]});
+              else
+                other_labels+=(${label});
+              fi
+            done
+            # Collect only ess titles
+            ess_title_prefixes=()
+            if [[ ${#ess_labels[@]} -eq 1 ]]; then
+              ess_title_prefixes+=(${ess_labels[0]});
+            elif [[ ${#ess_labels[@]} -gt 1 ]]; then
+              ess_title_prefixes+=('ess');
+            fi
+            # Combine all title prefixes
+            label_to_title=(${ess_title_prefixes[@]} ${other_labels[@]});
+            # Capitalize title prefixes
+            title_prefixes=();
+            for title in ${label_to_title[@]}; do
+              title_prefixes+=(${title^^});
+            done
+            title_prefix="[${title_prefixes[@]}]";
+          fi
+          echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
+      - id: title-prefix-correct
+        name: Title already has correct prefix.
+        if: ${{ startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) }}
+        run: echo "Title already has prefix ${title_prefix}."
+      - id: report-title-prefix-unexpected
+        name: Title already has prefix but not expected one.
+        if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && startsWith( env.original_title, '[' ) }}
+        run: |
+          echo "Title already has prefix but not same as the expected one. Reporting in the comment...";
+          echo "Hi! Your PR has unexpected title. Recommended prefix is: ${title_prefix}." >> pr-comment.md;
+          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
+          gh pr comment ${PR_NUM} \
+            --edit-last \
+            --create-if-none \
+            -F pr-comment.md;
+      - id: report-title-prefix-none
+        name: Add title prefix.
+        if: ${{ !startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) && !startsWith( env.original_title, '[' ) }}
+        env:
+           title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
+        run: |
+          echo "Title doesn't have expected prefix... adding one...";
+          gh pr edit ${PR_NUM} --title "${title_prefix} ${original_title}";
+          echo "Hi! Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
+          echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
+          gh pr comment ${PR_NUM} \
+            --edit-last \
+            --create-if-none \
+            -F pr-comment.md;

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -104,6 +104,7 @@ jobs:
     # If there is any new label or new title
     if: ${{ needs.check-pr.outputs.new_labels || needs.check-pr.outputs.new_title }}
     steps:
+      - uses: actions/checkout@v6
       - name: Add new labels to the PR
         id: add-new-labels
         if: ${{ needs.check-pr.outputs.new_labels }}

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -125,6 +125,7 @@ jobs:
             else
               title_prefix="[${label}]";
             fi
+            title_prefix=${title_prefix^^};
           # Handle ultiple labels
           elif [[ ${#labels[@]} -gt 1  ]]; then
             ess_labels=();

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -25,9 +25,9 @@ env:
   PR_NUM: ${{ github.event.pull_request.number }}
 
 jobs:
-  check-pr-labels:
+  check-pr:
     name: Check Labels
-    runs-on: ubuntu-slim-24.04
+    runs-on: ubuntu-slim
     outputs:
       all_labels: ${{ steps.all-labels.outputs.all_labels }}
       new_labels: ${{ steps.new-labels.outputs.new_labels }}
@@ -37,8 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch origin ${{ github.base_ref }}
-      - id: all-labels
-        name: Collect all expected labels based on the change.
+      - name: Collect all expected labels based on the change.
+        id: all-labels        
         run: |
           DIFFFILES=($(git diff --name-only origin/${{ github.base_ref }}));
           labels=($(for diff_file in ${DIFFFILES[@]}; do
@@ -52,8 +52,8 @@ jobs:
             done | sort -u));
           echo "Found labels to add: ${labels[@]}";
           echo "all_labels=${labels[@]}" >> "$GITHUB_OUTPUT";
-      - id: new-labels
-        name: Collect labels that need to be added among all_labels.
+      - name: Collect labels that need to be added among all_labels.
+        id: new-labels        
         env:
            all_labels: ${{ steps.all-labels.outputs.all_labels }}
         run: |
@@ -68,42 +68,12 @@ jobs:
             fi
           done
           echo "new_labels=${new_labels[@]}" >> "$GITHUB_OUTPUT";
-      - id: title-check
-        name: Check the title prefix.
+      - name: Check the title prefix.
+        id: title-check
+        if: ${{ steps.all-labels.outputs.all_labels && !startsWith( github.event.pull_request.title, '[' ) }}
         env:
           all_labels: ${{ steps.all-labels.outputs.all_labels }}
           new_labels: ${{ steps.new-labels.outputs.new_labels }}
-        run: |
-          labels=(${all_labels});
-          # Only one label
-          if [[ ${#labels[@]} -eq 1  ]]; then
-            title_prefix="[${labels[0]^^}]";
-            echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
-            echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
-          # Ignore multiple labels
-          elif [[ ${#labels[@]} -gt 1  ]]; then
-            echo "There are multiple labels found for this PR. Skipping making a new title...";
-          fi
-
-  check-pr-title:
-    name: Title Prefix
-    runs-on: ubuntu-slim-24.04
-    needs:
-      - check-pr-labels
-    if: |
-      ${{ ( github.event.action == 'opened' || github.event.action == 'reopened' ) &&
-        !startsWith( github.event.pull_request.title, '[' ) }}
-    env:
-      PR_NUM: ${{ github.event.pull_request.number }}
-      all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
-      original_title: ${{ github.event.pull_request.title }}
-    outputs:
-      title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
-      new_title: ${{ steps.title-prefix.outputs.new_title }}
-    steps:
-      - uses: actions/checkout@v6
-      - id: title-prefix
-        name: Compose title prefix.
         run: |
           labels=(${all_labels});
           # Only one label
@@ -120,44 +90,43 @@ jobs:
     name: Edit PR with New Labels or Title Prefix and Report
     runs-on: ubuntu-slim-24.04
     needs:
-      - check-pr-labels
-      - check-pr-title
+      - check-pr
     env:
-       all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
-       new_labels: ${{ needs.check-pr-labels.outputs.new_labels }}
-       title_prefix: ${{ needs.check-pr-title.outputs.title_prefix }}
-       new_title: ${{ needs.check-pr-title.outputs.new_title }}
+       all_labels: ${{ needs.check-pr.outputs.all_labels }}
+       new_labels: ${{ needs.check-pr.outputs.new_labels }}
+       title_prefix: ${{ needs.check-pr.outputs.title_prefix }}
+       new_title: ${{ needs.check-pr.outputs.new_title }}
        # The bot needs this token for editting PR.
        GH_TOKEN: ${{ github.token }}
     permissions:
       # The bot write comments, add labels or update the title of PR.
       pull-requests: write
     # If there is any new label or new title
-    if: ${{ needs.check-pr-labels.outputs.new_labels || needs.check-pr-title.outputs.new_title }}
+    if: ${{ needs.check-pr.outputs.new_labels || needs.check-pr.outputs.new_title }}
     steps:
       - name: Add new labels to the PR
         id: add-new-labels
-        if: ${{ needs.check-pr-labels.outputs.new_labels }}
+        if: ${{ needs.check-pr.outputs.new_labels }}
         run: |
           combined_label=${new_labels[0]};
           for label in ${new_labels[@]:1}; do combined_label="${combined_label},${label}"; done
           gh pr edit ${PR_NUM} --add-label ${combined_label};
       - name: Collect comments about the new labels
         id: new-labels-add-to-report
-        if: ${{ needs.check-pr-labels.outputs.new_labels }}
+        if: ${{ needs.check-pr.outputs.new_labels }}
         run: |
           echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
           echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
           echo "These labels were missing: ${new_labels}" >> pr-comment.md;
       - name: Add missing title prefix to the PR
         id: edit-title-prefix
-        if: ${{ needs.check-pr-title.outputs.new_title }}
+        if: ${{ needs.check-pr.outputs.new_title }}
         run: |
           echo "Title doesn't have any relevant prefix... adding one...";
           gh pr edit ${PR_NUM} --title "${new_title}";
       - name: Collect comments about the new title
         id: new-title-add-to-report
-        if: ${{ needs.check-pr-title.outputs.new_title }}
+        if: ${{ needs.check-pr.outputs.new_title }}
         run: |
           if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi
           echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;

--- a/.github/workflows/pr-vibe-check.yml
+++ b/.github/workflows/pr-vibe-check.yml
@@ -21,16 +21,13 @@ concurrency:
   # Even if the pull request has same reference, it should also run again if it's a different PR.
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.pull_request.number }}
 
-permissions:
-  # The bot write comments, add labels or update the title of PR.
-  pull-requests: write
+env:
+  PR_NUM: ${{ github.event.pull_request.number }}
 
 jobs:
   check-pr-labels:
-    name: Labels
-    runs-on: ubuntu-24.04
-    env:
-      PR_NUM: ${{ github.event.pull_request.number }}
+    name: Check Labels
+    runs-on: ubuntu-slim-24.04
     outputs:
       all_labels: ${{ steps.all-labels.outputs.all_labels }}
       new_labels: ${{ steps.new-labels.outputs.new_labels }}
@@ -54,6 +51,7 @@ jobs:
           echo "Found labels to add: ${labels[@]}";
           echo "all_labels=${labels[@]}" >> "$GITHUB_OUTPUT";
       - id: new-labels
+        name: Collect labels that need to be added among all_labels.
         env:
            all_labels: ${{ steps.all-labels.outputs.all_labels }}
            GH_TOKEN: ${{ github.token }}
@@ -64,51 +62,29 @@ jobs:
             if [[ "$EXISTING_LABELS" == *"${label}"* ]]; then
           	  echo "${label} is already added to the current PR.";
             else
+              echo "Found a new label to be added: ${label}";
               new_labels+=("${label}");
-          	  gh pr edit ${PR_NUM} --add-label ${label};
             fi
           done
           echo "new_labels=${new_labels[@]}" >> "$GITHUB_OUTPUT";
-      - id: new-labels-report
-        env:
-           all_labels: ${{ steps.all-labels.outputs.all_labels }}
-           new_labels: ${{ steps.new-labels.outputs.new_labels }}
-           GH_TOKEN: ${{ github.token }}
-        if: ${{ steps.new-labels.outputs.new_labels }}
-        run: |
-          echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
-          echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
-          echo "These labels were missing: ${new_labels}" >> pr-comment.md;
-          gh pr comment ${PR_NUM} -F pr-comment.md;
-      - id: export-comment
-        if: ${{ steps.new-labels.outputs.new_labels }}
-        uses: actions/upload-artifact@v7
-        with:
-          path: pr-comment.md
-          name: pr-comment.md
-          if-no-files-found: ignore
 
   check-pr-title:
     name: Title Prefix
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim-24.04
     needs:
       - check-pr-labels
-    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }} # Only when it's (re)opened.
+    if: |
+      ${{ ( github.event.action == 'opened' || github.event.action == 'reopened' ) &&
+        !startsWith( github.event.pull_request.title, '[' ) }}
     env:
       PR_NUM: ${{ github.event.pull_request.number }}
       all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
       original_title: ${{ github.event.pull_request.title }}
     outputs:
       title_prefix: ${{ steps.title-prefix.outputs.title_prefix }}
+      new_title: ${{ steps.title-prefix.outputs.new_title }}
     steps:
       - uses: actions/checkout@v6
-      - id: download-comment
-        uses: actions/download-artifact@v8
-        continue-on-error: true  # pre-commit.md might not exist.
-        with:
-          path: ./
-          name: pr-comment.md
-      - run: if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; echo "Found existing pr-comment file."; cat pr-comment.md; else echo "Hi!" >> pre-comment.md; fi
       - id: title-prefix
         name: Compose title prefix.
         run: |
@@ -126,7 +102,7 @@ jobs:
               title_prefix="[${label}]";
             fi
             title_prefix=${title_prefix^^};
-          # Handle ultiple labels
+          # Handle multiple labels
           elif [[ ${#labels[@]} -gt 1  ]]; then
             ess_labels=();
             other_labels=();
@@ -159,6 +135,7 @@ jobs:
             title_prefix="[${title_prefixes[@]}]";
           fi
           echo "title_prefix=${title_prefix}" >> "$GITHUB_OUTPUT";
+          echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
       - id: title-prefix-correct
         name: Title already has correct prefix.
         if: ${{ startsWith( env.original_title, steps.title-prefix.outputs.title_prefix ) }}
@@ -185,9 +162,39 @@ jobs:
         run: |
           echo "Title doesn't have expected prefix... adding one...";
           gh pr edit ${PR_NUM} --title "${title_prefix} ${original_title}";
+          echo "new_title=${title_prefix} ${original_title}" >> "$GITHUB_OUTPUT";
           echo "Your PR title didn't have any prefix yet. I added the prefix: ${title_prefix} to the title." >> pr-comment.md;
           echo "But feel free to use your own...! Bye 👋...!" >> pr-comment.md;
           gh pr comment ${PR_NUM} \
             --edit-last \
             --create-if-none \
             -F pr-comment.md;
+
+  edit-pr:
+    name: Edit and Report New Labels or Title Prefix
+    runs-on: ubuntu-slim-24.04
+    env:
+       all_labels: ${{ needs.check-pr-labels.outputs.all_labels }}
+       new_labels: ${{ needs.check-pr-labels.outputs.new_labels }}
+       GH_TOKEN: ${{ github.token }}
+    permissions:
+      # The bot write comments, add labels or update the title of PR.
+      pull-requests: write
+    needs:
+      - check-pr-labels
+    if: ${{ needs.check-pr-labels.outputs.new_labels }}
+    steps:
+      - id: add-new-labels
+        run: |
+          combined_label=${new_labels[0]};
+          for label in ${new_labels[@]:1}; do combined_label="${combined_label},${label}"; done
+          gh pr edit ${PR_NUM} --add-label ${combined_label};
+      - id: new-labels-report
+        run: |
+          echo "Hi! Your PR was missing some labels 🔖 so I added them." >> pr-comment.md;
+          echo "It looks like you're working on these packages/features: ${all_labels}" >> pr-comment.md;
+          echo "These labels were missing: ${new_labels}" >> pr-comment.md;
+          gh pr comment ${PR_NUM} -F pr-comment.md;
+      - id: new-title-report
+        run: |
+          if [[ -f pr-commit.md ]]; then echo "\nHi Again!" >> pre-comment.md; else echo "Hi!" >> pre-comment.md; fi


### PR DESCRIPTION
I tested it in this PR and another one: https://github.com/YooSunYoung/ess/pull/10

And tested with multiple package changes: https://github.com/YooSunYoung/ess/pull/11

Expected behavior: Add prefix or labels based on the file changes.

They are checked when the PR is opened, reopened or closed.

## Label mapping
`docs/` -> `documentation`
`.github/` -> `CI`
`packages/{package}` -> `{package}`

## Title prefix mapping

Title prefix is composed based on the labels that the PR needs.

If there is a single label found,
It tries to use the label as the title prefix 
It also capitalizes label name.