### PR TITLE
feat: default to 0 detector rotation

### DIFF
--- a/packages/essreflectometry/src/ess/estia/corrections.py
+++ b/packages/essreflectometry/src/ess/estia/corrections.py
@@ -55,6 +55,12 @@ def correct_by_footprint(da: sc.DataArray) -> sc.DataArray:
     return da / sc.sin(da.coords['theta'])
 
 
+def assume_time_series_constant_with_zero_default_value_if_empty(da: sc.DataArray):
+    '''Converts a time series to a single value by taking the average.
+    If the time series if empty it returns the default value 0.'''
+    return da.mean() if len(da) > 0 else sc.scalar(0.0, unit=da.unit)
+
+
 default_corrections = {correct_by_proton_current, correct_by_footprint}
 
 providers = (add_coords_masks_and_apply_corrections,)

--- a/packages/essreflectometry/src/ess/estia/workflow.py
+++ b/packages/essreflectometry/src/ess/estia/workflow.py
@@ -3,6 +3,8 @@
 
 import sciline
 import scipp as sc
+import scippnexus as snx
+from ess.reduce.nexus.types import TransformationTimeFilter
 
 from ..reflectometry import providers as reflectometry_providers
 from ..reflectometry import supermirror
@@ -105,4 +107,12 @@ def EstiaWorkflow() -> sciline.Pipeline:
         workflow.insert(provider)
     for name, param in default_parameters().items():
         workflow[name] = param
+
+    workflow[TransformationTimeFilter[snx.NXdetector, RunType]] = (
+        # Default to zero detector rotation if the log is empty.
+        # In practice it should never be empty, and it cannot be reduced,
+        # but this default makes it possible to at least load the data
+        # for visualization.
+        lambda da: da[0] if len(da) > 0 else sc.scalar(0.0, unit=da.unit)
+    )
     return workflow

--- a/packages/essreflectometry/src/ess/estia/workflow.py
+++ b/packages/essreflectometry/src/ess/estia/workflow.py
@@ -113,6 +113,6 @@ def EstiaWorkflow() -> sciline.Pipeline:
         # In practice it should never be empty, and it cannot be reduced,
         # but this default makes it possible to at least load the data
         # for visualization.
-        lambda da: da[0] if len(da) > 0 else sc.scalar(0.0, unit=da.unit)
+        lambda da: da.mean() if len(da) > 0 else sc.scalar(0.0, unit=da.unit)
     )
     return workflow

--- a/packages/essreflectometry/src/ess/estia/workflow.py
+++ b/packages/essreflectometry/src/ess/estia/workflow.py
@@ -113,6 +113,6 @@ def EstiaWorkflow() -> sciline.Pipeline:
         # In practice it should never be empty, and it cannot be reduced,
         # but this default makes it possible to at least load the data
         # for visualization.
-        lambda da: da.mean() if len(da) > 0 else sc.scalar(0.0, unit=da.unit)
+        corrections.assume_time_series_constant_with_zero_default_value_if_empty
     )
     return workflow


### PR DESCRIPTION
Makes the default ESTIA workflow more lenient by allowing empty detector transformations.

This is useful to be able to load and inspect the non-position related data without too much ceremony.