### PR TITLE
feat: make DetectorBankSizes determine pixel binning of McStas data

### DIFF
--- a/packages/essdiffraction/src/ess/beer/io.py
+++ b/packages/essdiffraction/src/ess/beer/io.py
@@ -10,6 +10,8 @@ import scipp as sc
 import scipp.constants
 from ess.powder.types import CaveMonitor, RunType, WavelengthMonitor
 
+from ess.reduce.nexus.types import DetectorBankSizes
+
 from .types import (
     DetectorBank,
     Filename,
@@ -146,7 +148,37 @@ def _effective_chopper_position_from_mode(
         raise ValueError(f'Unkonwn chopper mode {mode}.')
 
 
-def _load_beer_mcstas(f, north_or_south=None, number=None):
+def _load_beer_mcstas(f, *, north_or_south=None, number=None, detector_sizes):
+    # Allow the keys of detector_sizes to be both the
+    # NeXus detector name or DetectorBank enum.
+    # It makes the code a bit more complex here, but I think it's an easy mistake
+    # to make for the user and it makes sense to handle it gracefully.
+    normalized_detector_sizes = {
+        (
+            'south'
+            if key in (DetectorBank.south, 'south_detector')
+            else 'north'
+            if key in (DetectorBank.north, 'north_detector')
+            else key
+        ): value
+        for key, value in detector_sizes.items()
+    }
+    if north_or_south is not None:
+        # In newer files the bank is determined by a name (north or south).
+        sizes = normalized_detector_sizes[north_or_south]
+    else:
+        # In older files the detector bank is determined by an index.
+        if number == 1:
+            sizes = normalized_detector_sizes['south']
+        elif number == 2:
+            sizes = normalized_detector_sizes['north']
+        else:
+            raise ValueError(
+                'Could not determine detector sizes from provided '
+                f'`DetectorBankSizes`: {detector_sizes}. '
+                'Expected keys: "south_detector" and "north_detector".'
+            )
+
     positions = {
         name: f'/entry1/instrument/components/{key}/Position'
         for key in f['/entry1/instrument/components']
@@ -254,8 +286,8 @@ def _load_beer_mcstas(f, north_or_south=None, number=None):
     # Bin detector panel into rectangular "pixels"
     # similar in size to the physical detector pixels.
     da = da.bin(
-        y=sc.linspace('y', -0.5, 0.5, 201, unit='m'),
-        x=sc.linspace('x', -0.5, 0.5, 501, unit='m'),
+        y=sc.linspace('y', -0.5, 0.5, sizes['y'] + 1, unit='m'),
+        x=sc.linspace('x', -0.5, 0.5, sizes['x'] + 1, unit='m'),
     )
 
     # Compute the position of each pixel in the global coordinate system.
@@ -317,7 +349,9 @@ def _load_beer_mcstas(f, north_or_south=None, number=None):
     return da
 
 
-def load_beer_mcstas(f: str | Path | h5py.File, bank: DetectorBank) -> sc.DataArray:
+def load_beer_mcstas(
+    f: str | Path | h5py.File, bank: DetectorBank, detector_sizes: DetectorBankSizes
+) -> sc.DataArray:
     '''Load beer McStas data from a file to a data array.'''
     if not isinstance(bank, DetectorBank):
         raise ValueError(
@@ -326,20 +360,30 @@ def load_beer_mcstas(f: str | Path | h5py.File, bank: DetectorBank) -> sc.DataAr
 
     if isinstance(f, str | Path):
         with h5py.File(f) as ff:
-            return load_beer_mcstas(ff, bank=bank)
+            return load_beer_mcstas(ff, bank=bank, detector_sizes=detector_sizes)
 
     if len(list(_find_all_h5(f['/entry1/data'], '.*bank', nxclass='NXdata'))) < 8:
         # If we don't find ~13 detectors, then assume the detectors are 2D
         if len(list(_find_all_h5(f['/entry1/data'], '.*south', nxclass='NXdata'))) > 0:
-            return _load_beer_mcstas(f, north_or_south=bank.name)
+            return _load_beer_mcstas(
+                f, north_or_south=bank.name, detector_sizes=detector_sizes
+            )
 
         return _load_beer_mcstas(
-            f, north_or_south=None, number=1 if bank == DetectorBank.south else 2
+            f,
+            north_or_south=None,
+            number=1 if bank == DetectorBank.south else 2,
+            detector_sizes=detector_sizes,
         )
 
     return sc.concat(
         [
-            _load_beer_mcstas(f, north_or_south=bank.name, number=number)
+            _load_beer_mcstas(
+                f,
+                north_or_south=bank.name,
+                number=number,
+                detector_sizes=detector_sizes,
+            )
             for number in range(1, 13)
         ],
         dim='panel',
@@ -398,10 +442,9 @@ def load_beer_mcstas_monitor(f: str | Path | h5py.File):
 
 
 def load_beer_mcstas_provider(
-    fname: Filename[RunType],
-    bank: DetectorBank,
+    fname: Filename[RunType], bank: DetectorBank, detector_bank_sizes: DetectorBankSizes
 ) -> RawDetector[RunType]:
-    return load_beer_mcstas(fname, bank)
+    return load_beer_mcstas(fname, bank, detector_bank_sizes)
 
 
 def load_beer_mcstas_monitor_provider(

--- a/packages/essdiffraction/src/ess/beer/io.py
+++ b/packages/essdiffraction/src/ess/beer/io.py
@@ -151,8 +151,9 @@ def _effective_chopper_position_from_mode(
 def _load_beer_mcstas(f, *, north_or_south=None, number=None, detector_sizes):
     # Allow the keys of detector_sizes to be both the
     # NeXus detector name or DetectorBank enum.
-    # It makes the code a bit more complex here, but I think it's an easy mistake
-    # to make for the user and it makes sense to handle it gracefully.
+    # It makes the code a bit more complex here, but I think mixing them up
+    # is an easy mistake to make and it makes sense
+    # to handle that gracefully.
     normalized_detector_sizes = {
         (
             'south'

--- a/packages/essdiffraction/src/ess/beer/workflow.py
+++ b/packages/essdiffraction/src/ess/beer/workflow.py
@@ -28,6 +28,10 @@ from .types import (
 
 default_parameters = {
     PulseLength: sc.scalar(0.003, unit='s'),
+    DetectorBankSizes: {
+        'south_detector': {'y': 200, 'x': 500},
+        'north_detector': {'y': 200, 'x': 500},
+    },
 }
 
 
@@ -93,10 +97,6 @@ def BeerPowderWorkflow(
         monitor_types=[BunkerMonitor, CaveMonitor],
         **kwargs,
     )
-    wf[DetectorBankSizes] = {
-        'south_detector': {'y': 200, 'x': 500},
-        'north_detector': {'y': 200, 'x': 500},
-    }
     wf[NeXusName[CaveMonitor]] = "monitor_cave"
 
     for provider in itertools.chain(powder_providers, convert_pulse_shaping):

--- a/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
+++ b/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
@@ -20,10 +20,10 @@ from ess.beer.io import (
     mcstas_chopper_delay_from_mode_new_simulations,
 )
 from ess.beer.types import DetectorBank, DHKLList, WavelengthDetector
-from ess.powder.types import ElasticCoordTransformGraph, SampleRun
+from ess.powder.types import ElasticCoordTransformGraph, RawDetector, SampleRun
 from scipp.testing import assert_allclose
 
-from ess.reduce.nexus.types import Filename
+from ess.reduce.nexus.types import DetectorBankSizes, Filename
 
 
 def test_can_reduce_using_known_peaks_workflow():
@@ -97,8 +97,13 @@ def test_pulse_shaping_workflow():
 
 
 def test_can_load_3d_detector():
-    load_beer_mcstas(mcstas_few_neutrons_3d_detector_example(), DetectorBank.north)
-    da = load_beer_mcstas(mcstas_few_neutrons_3d_detector_example(), DetectorBank.south)
+    sizes = {'north_detector': {'x': 10, 'y': 20}, 'south_detector': {'x': 10, 'y': 20}}
+    load_beer_mcstas(
+        mcstas_few_neutrons_3d_detector_example(), DetectorBank.north, sizes
+    )
+    da = load_beer_mcstas(
+        mcstas_few_neutrons_3d_detector_example(), DetectorBank.south, sizes
+    )
     assert 'panel' in da.dims
 
 
@@ -108,3 +113,27 @@ def test_can_load_monitor():
     assert 'position' in da.coords
     assert da.coords['position'].dtype == sc.DType.vector3
     assert da.coords['position'].unit == 'm'
+
+
+@pytest.mark.parametrize(
+    ('bank_in_sizes', 'bank'),
+    [
+        ('south_detector', DetectorBank.south),
+        ('north_detector', DetectorBank.north),
+        (DetectorBank.south, DetectorBank.south),
+        (DetectorBank.north, DetectorBank.north),
+    ],
+)
+@pytest.mark.parametrize(
+    'fname', [mcstas_silicon_new_model(7), mcstas_more_neutrons_3d_detector_example()]
+)
+def test_detector_bank_size_parameter_determines_loaded_detector_size(
+    bank_in_sizes, bank, fname
+):
+    wf = BeerMcStasWorkflowPulseShaping()
+    wf[Filename[SampleRun]] = fname
+    wf[DetectorBank] = bank
+    wf[DetectorBankSizes] = {bank_in_sizes: {'x': 10, 'y': 20}}
+    res = wf.compute(RawDetector[SampleRun])
+    assert res.sizes['x'] == 10
+    assert res.sizes['y'] == 20


### PR DESCRIPTION
Fixes the issue Celine noticed that `DetectorBankSizes` doesn't actually determine sizes of loaded McStas detector data.