### PR TITLE
[essreduce]: Allow single transformation timepoint

### DIFF
--- a/packages/essreduce/src/ess/reduce/nexus/workflow.py
+++ b/packages/essreduce/src/ess/reduce/nexus/workflow.py
@@ -306,7 +306,12 @@ def _apply_time_filter(
 ) -> sc.Variable | sc.DataArray:
     if transform.ndim == 0 or transform.sizes == {'time': 1}:
         return transform.data.squeeze()
-    return user_filter(transform)
+    filtered = user_filter(transform)
+    if isinstance(filtered, sc.DataArray) and (not filtered.dims):
+        # If the filter returns a 0-dim DataArray, we can safely extract the value.
+        # This is a common case when the filter selects a single time point.
+        filtered = filtered.data
+    return filtered
 
 
 def to_transformation(

--- a/packages/essreduce/tests/nexus/workflow_test.py
+++ b/packages/essreduce/tests/nexus/workflow_test.py
@@ -206,6 +206,26 @@ def test_to_transform_with_custom_time_filter(
     )
 
 
+def test_to_transform_with_time_filter_slice_single_value(
+    time_dependent_depends_on: snx.TransformationChain,
+) -> None:
+    def time_filter(transformation: sc.DataArray) -> sc.DataArray:
+        return transformation['time', 1]
+
+    transform = workflow.to_transformation(
+        time_dependent_depends_on,
+        TimeInterval(slice(sc.scalar(0.1, unit='s'), sc.scalar(1.9, unit='s'))),
+        time_filter=time_filter,
+    ).value
+
+    # Note that after slicing a single value, we should just have the Variable, not a
+    # DataArray.
+    expected = sc.vector([1.0, 2.0, 0.0], unit='m')
+    sc.testing.assert_identical(
+        transform * sc.vector([0.0, 0.0, 0.0], unit='m'), expected
+    )
+
+
 def test_given_no_sample_load_nexus_sample_returns_group_with_origin_depends_on(
     loki_tutorial_sample_run_60250: Path,
 ) -> None:


### PR DESCRIPTION
When we provide a transformation filter that slices a single value
```Py
wf = loki.LokiWorkflow()
wf[Filename[SampleRun]] = 'loki_051657_00000135.hdf'
wf[TransformationTimeFilter[sx.NXdetector, RunType]] = lambda da: da['time', 0].data
```
we ran into the error:
```
        if isinstance(total_transform, sc.DataArray):
            time_dependent = [t for t in chain if isinstance(t, sc.DataArray)]
>           times = [da.coords['time'][0] for da in time_dependent]
E           scipp._scipp.core.DimensionError: Slicing a scalar object is not possible.
```

We fix this by returning the `.data` if the result of the `apply_transformation` is a DataArray containing just a scalar value.