### PR TITLE
[LINTING] Update actionlint version to v1.7.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.3
+    rev: v1.7.10
     hooks:
       - id: actionlint
         # Disable because of false-positive SC2046


### PR DESCRIPTION
`ubuntu-slim` keyword for github action run-on field was added in 1.7.9