### PR TITLE
[CI] Pin pixi version and use frozen flag to run pixi command.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           pixi-version: v0.67.2
           frozen: true
           environments: lint
-      - run: pixi run -e lint lint
+      - run: pixi run --frozen -e lint lint
 
   test:
     name: Test ${{ matrix.package }}
@@ -111,7 +111,7 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}
 
   docs:
     name: Docs ${{ matrix.package }}
@@ -132,7 +132,7 @@ jobs:
           frozen: true
           environments: docs-${{ matrix.package }}
       - name: Build docs
-        run: pixi run docs-${{ matrix.package }}
+        run: pixi run --frozen docs-${{ matrix.package }}
       - uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
@@ -127,6 +128,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: docs-${{ matrix.package }}
       - name: Build docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           pixi-version: v0.67.2
           frozen: true
           environments: lint
-      - run: pixi run --frozen -e lint lint
+      - run: pixi run -e lint lint
 
   test:
     name: Test ${{ matrix.package }}
@@ -111,7 +111,7 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
 
   docs:
     name: Docs ${{ matrix.package }}
@@ -132,7 +132,7 @@ jobs:
           frozen: true
           environments: docs-${{ matrix.package }}
       - name: Build docs
-        run: pixi run --frozen docs-${{ matrix.package }}
+        run: pixi run docs-${{ matrix.package }}
       - uses: actions/upload-artifact@v7
         id: artifact-upload-step
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: lint
       - run: pixi run -e lint lint

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           frozen: true
           environments: docs-${{ inputs.package }}
       - name: Build docs
-        run: pixi run --frozen docs-${{ inputs.package }}
+        run: pixi run docs-${{ inputs.package }}
       - name: Prepare site
         if: ${{ inputs.publish }}
         run: |

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           frozen: true
           environments: docs-${{ inputs.package }}
       - name: Build docs
-        run: pixi run docs-${{ inputs.package }}
+        run: pixi run --frozen docs-${{ inputs.package }}
       - name: Prepare site
         if: ${{ inputs.publish }}
         run: |

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -36,6 +36,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: docs-${{ inputs.package }}
       - name: Build docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
@@ -46,6 +47,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: lb-${{ matrix.package }}
       - name: Test with lowest direct dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}
 
   lower-bound:
     name: Lower bound ${{ matrix.package }}
@@ -51,4 +51,4 @@ jobs:
           frozen: true
           environments: lb-${{ matrix.package }}
       - name: Test with lowest direct dependencies
-        run: pixi run -e lb-${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run --frozen -e lb-${{ matrix.package }} test ${{ matrix.package }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
 
   lower-bound:
     name: Lower bound ${{ matrix.package }}
@@ -51,4 +51,4 @@ jobs:
           frozen: true
           environments: lb-${{ matrix.package }}
       - name: Test with lowest direct dependencies
-        run: pixi run --frozen -e lb-${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run -e lb-${{ matrix.package }} test ${{ matrix.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           frozen: true
           environments: docs-${{ needs.determine-package.outputs.package }}
       - name: Build docs
-        run: pixi run --frozen docs-${{ needs.determine-package.outputs.package }}
+        run: pixi run docs-${{ needs.determine-package.outputs.package }}
       - name: Prepare site
         run: |
           PACKAGE=${{ needs.determine-package.outputs.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           frozen: true
           environments: docs-${{ needs.determine-package.outputs.package }}
       - name: Build docs
-        run: pixi run docs-${{ needs.determine-package.outputs.package }}
+        run: pixi run --frozen docs-${{ needs.determine-package.outputs.package }}
       - name: Prepare site
         run: |
           PACKAGE=${{ needs.determine-package.outputs.package }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: docs-${{ needs.determine-package.outputs.package }}
       - name: Build docs

--- a/.github/workflows/weekly-platform.yml
+++ b/.github/workflows/weekly-platform.yml
@@ -30,4 +30,4 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}

--- a/.github/workflows/weekly-platform.yml
+++ b/.github/workflows/weekly-platform.yml
@@ -30,4 +30,4 @@ jobs:
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests
-        run: pixi run --frozen -e ${{ matrix.package }} test ${{ matrix.package }}
+        run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}

--- a/.github/workflows/weekly-platform.yml
+++ b/.github/workflows/weekly-platform.yml
@@ -26,6 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
+          pixi-version: v0.67.2
           frozen: true
           environments: ${{ matrix.package }}
       - name: Run tests


### PR DESCRIPTION
## Frozen flag
CI failed when pixi tried to resovle lower-bound environment, which was not necessary for the task.
It looks like it's because of the missing frozen flag...?

Failed test in the merge queue: https://github.com/scipp/ess/actions/runs/25638109487/job/75253633834

This failure is also weird that it sometimes passed when I re-ran the failed job...
I didn't want to look too much deep into this issue though.

## Pixi version
Default pixi version of the setup-pixi action version is not pinned per action version.
If this is not specified, it seems like it installs the latest version of pixi.
The setup-pixi action readme says it just picks up whatever the runner has...?

I didn't really understand what it does from the description though:
> You can also use a preinstalled local version of pixi on the runner by not setting any of the pixi-version, pixi-url or pixi-bin-path inputs. This action will then try to find a local version of pixi in the runner's PATH.

I think it'll be safer if we pin the version of the pixi in the CI first, and then we upgrade them once in a while...?