### PR TITLE
[ESSDIFFRACTION] Fix beer geometry

### DIFF
--- a/packages/essdiffraction/src/ess/beer/io.py
+++ b/packages/essdiffraction/src/ess/beer/io.py
@@ -209,7 +209,7 @@ def _load_beer_mcstas(f, *, north_or_south=None, number=None, detector_sizes):
         positions['MCC'],
     )
     data = (
-        next(_find_all_h5(data_dir, f'.*{north_or_south}{number}'))
+        next(_find_all_h5(data_dir, f'.*{north_or_south}{number}_events'))
         if north_or_south is not None and number is not None
         else next(_find_all_h5(data_dir, f'.*{north_or_south}'))
         if north_or_south is not None
@@ -222,7 +222,7 @@ def _load_beer_mcstas(f, *, north_or_south=None, number=None, detector_sizes):
     ]
     detector_rotation = _find_h5(
         f['/entry1/instrument/components'],
-        f'.*nD_Mantid_?{north_or_south}_{number}.*'
+        f'.*nD_Mantid_?{north_or_south}_{number}$'
         if north_or_south is not None and number is not None
         else f'.*nD_Mantid_?{north_or_south}.*'
         if north_or_south is not None

--- a/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
+++ b/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
@@ -105,6 +105,9 @@ def test_can_load_3d_detector():
         mcstas_few_neutrons_3d_detector_example(), DetectorBank.south, sizes
     )
     assert 'panel' in da.dims
+    # Detector position is monotone in x.
+    panel_x_diff = np.diff(da.coords['detector_position'].fields.x.values)
+    assert (panel_x_diff > 0).all() or (panel_x_diff < 0).all()
 
 
 def test_can_load_monitor():

--- a/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
+++ b/packages/essdiffraction/tests/beer/mcstas_reduction_test.py
@@ -105,7 +105,7 @@ def test_can_load_3d_detector():
         mcstas_few_neutrons_3d_detector_example(), DetectorBank.south, sizes
     )
     assert 'panel' in da.dims
-    # Detector position is monotone in x.
+    # Detector position.x is monotone in panel dimension.
     panel_x_diff = np.diff(da.coords['detector_position'].fields.x.values)
     assert (panel_x_diff > 0).all() or (panel_x_diff < 0).all()
 


### PR DESCRIPTION
Issue was that detector 10 was loaded instead of detector 1.
Fix was to tighten the regex identifying the component.

We could consider rewriting the loader using McStasToX to avoid similar issues in the future.
But that might come with its own set of difficulties, so I'm not sure its worth it.