### PR TITLE
[ESSNMX] Save TOF 1d histogram

### DIFF
--- a/packages/essnmx/src/ess/nmx/_executable_helper.py
+++ b/packages/essnmx/src/ess/nmx/_executable_helper.py
@@ -10,13 +10,12 @@ from functools import partial
 from types import UnionType
 from typing import Literal, TypeGuard, TypeVar, Union, get_args, get_origin
 
-import scipp as sc
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
 from .configurations import (
-    AuxilaryOutputConfig,
+    AuxiliaryOutputConfig,
     InputConfig,
     OutputConfig,
     ReductionConfig,
@@ -196,7 +195,9 @@ def build_reduction_argument_parser() -> argparse.ArgumentParser:
     parser = add_args_from_pydantic_model(model_cls=InputConfig, parser=parser)
     parser = add_args_from_pydantic_model(model_cls=WorkflowConfig, parser=parser)
     parser = add_args_from_pydantic_model(model_cls=OutputConfig, parser=parser)
-    parser = add_args_from_pydantic_model(model_cls=AuxilaryOutputConfig, parser=parser)
+    parser = add_args_from_pydantic_model(
+        model_cls=AuxiliaryOutputConfig, parser=parser
+    )
     return parser
 
 
@@ -205,7 +206,7 @@ def reduction_config_from_args(args: argparse.Namespace) -> ReductionConfig:
         inputs=from_args(InputConfig, args),
         workflow=from_args(WorkflowConfig, args),
         output=from_args(OutputConfig, args),
-        aux=from_args(AuxilaryOutputConfig, args),
+        aux=from_args(AuxiliaryOutputConfig, args),
     )
 
 
@@ -226,30 +227,3 @@ def collect_matching_input_files(*input_file_patterns: str) -> list[pathlib.Path
 
     # Remove duplicates and sort
     return sorted({pathlib.Path(f).resolve() for f in input_files})
-
-
-def not_ascii_art(da: sc.DataArray, display):
-    t_dim = da.dim
-    n_row = min(da.sizes[t_dim] // 4, 50)
-    max_value = da.max().value
-    row_size = int(max_value // n_row)
-    stars = [list(("*" * int(val // row_size)).rjust(n_row)) for val in da.data.values]
-    stars = [
-        [stars[col_i][row_i] for col_i in range(len(stars))]
-        for row_i in range(len(stars[0]))
-    ]
-    stars = "\n".join("".join(c for c in row) for row in stars)
-
-    y_axis = f"max-count: {max_value} [{da.unit}]".ljust(da.sizes[t_dim], '-')
-    stars = y_axis + "\n" + stars
-    display("\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 2, '-'))
-    stars = "\n".join('│' + row for row in stars.split("\n"))
-    if t_dim in da.coords:
-        t_coord = da.coords[t_dim]
-        t_unit = str(t_coord.unit)
-        t_min, t_max = int(t_coord.min().value), int(t_coord.max().value)
-        xaxis = f"{t_min:.3g} [{t_unit}]".ljust(da.sizes[t_dim])
-        max_t_label = f"{t_max:.3g} [{t_unit}]"
-        xaxis += max_t_label
-        stars += f"\n{xaxis}"
-    display(stars)

--- a/packages/essnmx/src/ess/nmx/_executable_helper.py
+++ b/packages/essnmx/src/ess/nmx/_executable_helper.py
@@ -10,11 +10,18 @@ from functools import partial
 from types import UnionType
 from typing import Literal, TypeGuard, TypeVar, Union, get_args, get_origin
 
+import scipp as sc
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from .configurations import InputConfig, OutputConfig, ReductionConfig, WorkflowConfig
+from .configurations import (
+    AuxilaryOutputConfig,
+    InputConfig,
+    OutputConfig,
+    ReductionConfig,
+    WorkflowConfig,
+)
 
 
 def _validate_annotation(annotation) -> TypeGuard[type]:
@@ -189,6 +196,7 @@ def build_reduction_argument_parser() -> argparse.ArgumentParser:
     parser = add_args_from_pydantic_model(model_cls=InputConfig, parser=parser)
     parser = add_args_from_pydantic_model(model_cls=WorkflowConfig, parser=parser)
     parser = add_args_from_pydantic_model(model_cls=OutputConfig, parser=parser)
+    parser = add_args_from_pydantic_model(model_cls=AuxilaryOutputConfig, parser=parser)
     return parser
 
 
@@ -197,6 +205,7 @@ def reduction_config_from_args(args: argparse.Namespace) -> ReductionConfig:
         inputs=from_args(InputConfig, args),
         workflow=from_args(WorkflowConfig, args),
         output=from_args(OutputConfig, args),
+        aux=from_args(AuxilaryOutputConfig, args),
     )
 
 
@@ -217,3 +226,30 @@ def collect_matching_input_files(*input_file_patterns: str) -> list[pathlib.Path
 
     # Remove duplicates and sort
     return sorted({pathlib.Path(f).resolve() for f in input_files})
+
+
+def not_ascii_art(da: sc.DataArray, display):
+    t_dim = da.dim
+    n_row = min(da.sizes[t_dim] // 4, 50)
+    max_value = da.max().value
+    row_size = int(max_value // n_row)
+    stars = [list(("*" * int(val // row_size)).rjust(n_row)) for val in da.data.values]
+    stars = [
+        [stars[col_i][row_i] for col_i in range(len(stars))]
+        for row_i in range(len(stars[0]))
+    ]
+    stars = "\n".join("".join(c for c in row) for row in stars)
+
+    y_axis = f"max-count: {max_value} [{da.unit}]".ljust(da.sizes[t_dim], '-')
+    stars = y_axis + "\n" + stars
+    display("\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 2, '-'))
+    stars = "\n".join('│' + row for row in stars.split("\n"))
+    if t_dim in da.coords:
+        t_coord = da.coords[t_dim]
+        t_unit = str(t_coord.unit)
+        t_min, t_max = int(t_coord.min().value), int(t_coord.max().value)
+        xaxis = f"{t_min:.3g} [{t_unit}]".ljust(da.sizes[t_dim])
+        max_t_label = f"{t_max:.3g} [{t_unit}]"
+        xaxis += max_t_label
+        stars += f"\n{xaxis}"
+    display(stars)

--- a/packages/essnmx/src/ess/nmx/_nxlauetof_io.py
+++ b/packages/essnmx/src/ess/nmx/_nxlauetof_io.py
@@ -178,6 +178,8 @@ def load_essnmx_nxlauetof(file: str | FilePath | NeXusFile) -> sc.DataGroup:
             # The data array reconstruction is handled manually later.
             dg = f[()]
 
+        # Drop auxiliary output from the loaded result.
+        del dg['entry']['aux']
         _validate_entry(entry := f['entry'])
         _handle_sample(dg['entry']['sample'], entry['sample'])
         _handle_monitor(dg['entry']['control'], entry['control'])

--- a/packages/essnmx/src/ess/nmx/configurations.py
+++ b/packages/essnmx/src/ess/nmx/configurations.py
@@ -191,20 +191,6 @@ class AuxiliaryOutputConfig(BaseModel):
         "If not given, stem of the output file name will be used.",
         default="",
     )
-    no_tof_1d_in_file: bool = Field(
-        title="No TOF 1D distribution",
-        description="Skip saving TOF 1D distribution at `entry/aux` in the file.",
-        default=False,
-    )
-    no_png: bool = Field(
-        title="Skip Saving Plots",
-        description="Skip saving auxiliary plots in png files.",
-        default=False,
-    )
-
-    @property
-    def no_axilaries(self) -> bool:
-        return self.no_tof_1d_in_file and self.no_png
 
     @property
     def tof_1d_png_filename(self) -> str:

--- a/packages/essnmx/src/ess/nmx/configurations.py
+++ b/packages/essnmx/src/ess/nmx/configurations.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 import enum
+import pathlib
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -181,6 +182,62 @@ class WorkflowConfig(BaseModel):
     )
 
 
+class AuxiliaryOutputConfig(BaseModel):
+    # Add title of the basemodel
+    model_config = {"title": "Auxiliary Output Configuration"}
+    output_dir: str = Field(
+        title="Path to the Auxiliary Files Directory",
+        description="Directory to save auxiliary files into. "
+        "If not given, stem of the output file name will be used.",
+        default="",
+    )
+    no_png: bool = Field(
+        title="Skip Saving Plots",
+        description="Skip saving auxiliary plots in png files.",
+        default=False,
+    )
+
+    @property
+    def no_axilaries(self) -> bool:
+        return self.no_png
+
+    @property
+    def tof_1d_png_filename(self) -> str:
+        """Hard-coded png file name for tof 1D histgoram plot."""
+        return "essnmx-reduce-tof-1d.png"
+
+    def build_target_dir(self, output_file: str = "") -> pathlib.Path:
+        if self.output_dir:
+            return pathlib.Path(self.output_dir)
+        elif output_file:
+            output_file_path = pathlib.Path(output_file)
+            return output_file_path.parent / output_file_path.stem
+        else:
+            return pathlib.Path("essnmx-reduce-aux")
+
+    def check_output_dir(self, output_file: str = "") -> None:
+        """Raises if the expected auxiliary output directory path is invalid.
+
+        Raises
+        ------
+            - If the parent directory does not exist.
+            - If the path already exists but is not a directory.
+
+        """
+        target_dir = self.build_target_dir(output_file)
+        if not target_dir.parent.is_dir():
+            raise NotADirectoryError(
+                "Parent directory doesn't exist "
+                f"for the output files: {target_dir.parent}. "
+                "Please make sure the parent directory exists first."
+            )
+        if target_dir.exists() and not target_dir.is_dir():
+            raise NotADirectoryError(
+                f"Target Directory path exists but it is not a directory: {target_dir} "
+                "Please choose another directory path."
+            )
+
+
 class OutputConfig(BaseModel):
     # Add title of the basemodel
     model_config = {"title": "Output Configuration"}
@@ -212,6 +269,7 @@ class OutputConfig(BaseModel):
         description="Compress option of reduced output file.",
         default=Compression.BITSHUFFLE_LZ4,
     )
+    no_tof_histogram: bool = Field(title="", description="", default=False)
 
 
 class ReductionConfig(BaseModel):
@@ -220,10 +278,11 @@ class ReductionConfig(BaseModel):
     inputs: InputConfig
     workflow: WorkflowConfig = Field(default_factory=WorkflowConfig)
     output: OutputConfig = Field(default_factory=OutputConfig)
+    aux: AuxiliaryOutputConfig = Field(default_factory=AuxiliaryOutputConfig)
 
     @property
     def _children(self) -> list[BaseModel]:
-        return [self.inputs, self.workflow, self.output]
+        return [self.inputs, self.workflow, self.output, self.aux]
 
 
 def to_command_arguments(

--- a/packages/essnmx/src/ess/nmx/configurations.py
+++ b/packages/essnmx/src/ess/nmx/configurations.py
@@ -191,6 +191,11 @@ class AuxiliaryOutputConfig(BaseModel):
         "If not given, stem of the output file name will be used.",
         default="",
     )
+    no_tof_1d_in_file: bool = Field(
+        title="No TOF 1D distribution",
+        description="Skip saving TOF 1D distribution at `entry/aux` in the file.",
+        default=False,
+    )
     no_png: bool = Field(
         title="Skip Saving Plots",
         description="Skip saving auxiliary plots in png files.",
@@ -199,7 +204,7 @@ class AuxiliaryOutputConfig(BaseModel):
 
     @property
     def no_axilaries(self) -> bool:
-        return self.no_png
+        return self.no_tof_1d_in_file and self.no_png
 
     @property
     def tof_1d_png_filename(self) -> str:
@@ -269,7 +274,6 @@ class OutputConfig(BaseModel):
         description="Compress option of reduced output file.",
         default=Compression.BITSHUFFLE_LZ4,
     )
-    no_tof_histogram: bool = Field(title="", description="", default=False)
 
 
 class ReductionConfig(BaseModel):

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -396,7 +396,6 @@ def save_auxiliary_output(
     # Export TOF 1D distribution into entry/aux
     if (
         output_config
-        and isinstance(tof_histogram, sc.DataArray)
         and not output_config.skip_file_output
         and not aux_config.no_tof_1d_in_file
     ):

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -238,18 +238,11 @@ def reduction(
     # Check the file output configuration before we start heavy computation.
     if not config.output.skip_file_output:
         _check_file(config.output.output_file, config.output.overwrite)
-    elif not (config.output.skip_file_output or config.aux.no_axilaries):
         config.aux.check_output_dir()
 
     display = _retrieve_display(logger, display)
     input_file_path = _retrieve_input_file(config.inputs.input_file).resolve()
     display(f"Input file: {input_file_path}")
-
-    output_file_path = pathlib.Path(config.output.output_file).resolve()
-    display(f"Output file: {output_file_path}")
-
-    auxilary_output_dir = config.aux.build_target_dir(output_file_path.as_posix())
-    display(f"Auxiliary output dir: {auxilary_output_dir}")
 
     detector_names = select_detector_names(detector_ids=config.inputs.detector_ids)
 
@@ -329,20 +322,27 @@ def reduction(
         results.lookup_table = base_wf.compute(LookupTable)
 
     if not config.output.skip_file_output:
-        save_results(results=results, output_config=config.output)
-        if not config.aux.no_axilaries:
-            save_auxiliary_output(
-                results=results,
-                output_config=config.output,
-                aux_config=config.aux,
-                output_dir=auxilary_output_dir,
-                display=display,
-            )
+        save_results(
+            results=results, output_config=config.output, aux_config=config.aux
+        )
 
     return results
 
 
-def save_results(*, results: NMXLauetof, output_config: OutputConfig) -> None:
+def save_results(
+    *,
+    results: NMXLauetof,
+    output_config: OutputConfig,
+    aux_config: AuxiliaryOutputConfig | None = None,
+    display: Callable | None = None,
+) -> None:
+    aux_config = aux_config or AuxiliaryOutputConfig()
+    output_file_path = pathlib.Path(output_config.output_file).resolve()
+    aux_output_dir = aux_config.build_target_dir(output_file_path.as_posix())
+    if display:
+        display(f"Output file: {output_file_path}")
+        display(f"Auxiliary output dir: {aux_output_dir}")
+
     # Validate if results have expected fields
     export_static_metadata_as_nxlauetof(
         sample_metadata=results.sample,
@@ -370,6 +370,14 @@ def save_results(*, results: NMXLauetof, output_config: OutputConfig) -> None:
         else:
             raise ValueError(f"Detector counts histogram missing in {detector_name}")
 
+    save_auxiliary_output(
+        results=results,
+        output_config=output_config,
+        aux_config=aux_config,
+        output_dir=aux_output_dir,
+        display=display,
+    )
+
 
 def save_auxiliary_output(
     *,
@@ -394,11 +402,7 @@ def save_auxiliary_output(
     ).sum()
 
     # Export TOF 1D distribution into entry/aux
-    if (
-        output_config
-        and not output_config.skip_file_output
-        and not aux_config.no_tof_1d_in_file
-    ):
+    if output_config and not output_config.skip_file_output:
         from .nexus import export_tof_distribution_nxlauetof
 
         export_tof_distribution_nxlauetof(
@@ -406,18 +410,13 @@ def save_auxiliary_output(
             output_file=output_config.output_file,
         )
     # Export TOF 1D plot
-    if isinstance(tof_histogram, sc.DataArray) and not aux_config.no_png:
-        tof_histogram.plot(
-            title="Tof Distribution (All Panels Summed)",
-            grid=True,
-        ).save(output_dir / aux_config.tof_1d_png_filename)
+    tof_histogram.plot(
+        title="Tof Distribution (All Panels Summed)",
+        grid=True,
+    ).save(output_dir / aux_config.tof_1d_png_filename)
+
     # Print(log) TOF 1D plot
-    if (
-        isinstance(tof_histogram, sc.DataArray)
-        and output_config
-        and output_config.verbose
-        and display is not None
-    ):
+    if output_config and output_config.verbose and display is not None:
         da = tof_histogram
         t_dim = da.dim
         original_tbin_size = da.sizes[t_dim]

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -19,7 +19,7 @@ from ._executable_helper import (
     reduction_config_from_args,
 )
 from .configurations import (
-    AuxilaryOutputConfig,
+    AuxiliaryOutputConfig,
     OutputConfig,
     ReductionConfig,
     TimeBinCoordinate,
@@ -330,8 +330,8 @@ def reduction(
 
     if not config.output.skip_file_output:
         save_results(results=results, output_config=config.output)
-        if not config.aux.no_axilaries:
-            save_plots(
+        if not (config.aux.no_axilaries and config.output.no_tof_histogram):
+            save_auxiliary_output(
                 results=results,
                 output_config=config.output,
                 aux_config=config.aux,
@@ -371,11 +371,11 @@ def save_results(*, results: NMXLauetof, output_config: OutputConfig) -> None:
             raise ValueError(f"Detector counts histogram missing in {detector_name}")
 
 
-def save_plots(
+def save_auxiliary_output(
     *,
     results: NMXLauetof,
     output_config: OutputConfig,
-    aux_config: AuxilaryOutputConfig,
+    aux_config: AuxiliaryOutputConfig,
     output_dir: pathlib.Path,
     display: Callable | None = None,
 ) -> None:
@@ -385,6 +385,18 @@ def save_plots(
         for det_res in results.instrument.detectors.values()
         if isinstance(det_res.data, sc.DataArray)
     ).sum()
+    if (
+        isinstance(tof_histogram, sc.DataArray)
+        and not output_config.skip_file_output
+        and not output_config.no_tof_histogram
+    ):
+        from .nexus import export_tof_distribution_nxlauetof
+
+        export_tof_distribution_nxlauetof(
+            tof_histogram=tof_histogram,
+            output_file=output_config.output_file,
+        )
+
     if isinstance(tof_histogram, sc.DataArray) and not aux_config.no_png:
         tof_histogram.plot(
             title="Tof Distribution (All Panels Summed)",

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -421,6 +421,11 @@ def save_auxiliary_output(
     ):
         da = tof_histogram
         t_dim = da.dim
+        original_tbin_size = da.sizes[t_dim]
+        original_max_value = da.max().value
+        while (display_t_size := da.sizes[t_dim]) > 128:
+            da = da.rebin({t_dim: display_t_size // 2})
+
         n_row = min(da.sizes[t_dim] // 4, 50)
         max_value = da.max().value
         row_size = int(max_value // n_row)
@@ -433,7 +438,9 @@ def save_auxiliary_output(
         ]
         bars = "\n".join("".join(c for c in row) for row in bars)
 
-        y_axis = f"max-count: {max_value} [{da.unit}]".ljust(da.sizes[t_dim], '-')
+        y_axis = f"max-count: {original_max_value} [{da.unit}]".ljust(
+            da.sizes[t_dim], '-'
+        )
         bars = y_axis + "\n" + bars
         display(
             "\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 1, '─')
@@ -448,7 +455,12 @@ def save_auxiliary_output(
             max_t_label = f"{t_max:.3g} [{t_unit}]"
             xaxis = xaxis[: -len(max_t_label) + 2] + max_t_label
             bars += f"\n{xaxis}"
-            num_bins_label = f"({da.sizes[t_dim]} {t_dim} bins)"
+            num_bins_label = (
+                "*histogram rebinned for display* "
+                if da.sizes[t_dim] != original_tbin_size
+                else ""
+            )
+            num_bins_label += f"({original_tbin_size} {t_dim} bins)"
             bars += (
                 "\n└".ljust(da.sizes[t_dim] + 1 - len(num_bins_label), '─')
                 + num_bins_label

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -424,18 +424,26 @@ def save_auxiliary_output(
         y_axis = f"max-count: {max_value} [{da.unit}]".ljust(da.sizes[t_dim], '-')
         bars = y_axis + "\n" + bars
         display(
-            "\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 2, '─')
+            "\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 1, '─')
+            + '─┐'
         )
-        bars = "\n".join('│' + row for row in bars.split("\n"))
+        bars = "\n".join('│' + row + '│' for row in bars.split("\n"))
         if t_dim in da.coords:
             t_coord = da.coords[t_dim]
             t_unit = str(t_coord.unit)
             t_min, t_max = int(t_coord.min().value), int(t_coord.max().value)
             xaxis = f"{t_min:.3g} [{t_unit}]".ljust(da.sizes[t_dim])
             max_t_label = f"{t_max:.3g} [{t_unit}]"
-            xaxis = xaxis[:-10] + max_t_label
-            bars += f"\n{xaxis} ({da.sizes[t_dim]} {t_dim} bins)"
-        bars += "\n└".ljust(da.sizes[t_dim] + 2, '─')
+            xaxis = xaxis[: -len(max_t_label) + 2] + max_t_label
+            bars += f"\n{xaxis}"
+            num_bins_label = f"({da.sizes[t_dim]} {t_dim} bins)"
+            bars += (
+                "\n└".ljust(da.sizes[t_dim] + 1 - len(num_bins_label), '─')
+                + num_bins_label
+                + '─┘'
+            )
+        else:
+            bars += "\n└".ljust(da.sizes[t_dim] + 1, '─') + '┘'
         display(bars)
 
 

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -330,7 +330,7 @@ def reduction(
 
     if not config.output.skip_file_output:
         save_results(results=results, output_config=config.output)
-        if not (config.aux.no_axilaries and config.output.no_tof_histogram):
+        if not config.aux.no_axilaries:
             save_auxiliary_output(
                 results=results,
                 output_config=config.output,
@@ -374,21 +374,31 @@ def save_results(*, results: NMXLauetof, output_config: OutputConfig) -> None:
 def save_auxiliary_output(
     *,
     results: NMXLauetof,
-    output_config: OutputConfig,
+    output_config: OutputConfig | None = None,
     aux_config: AuxiliaryOutputConfig,
     output_dir: pathlib.Path,
     display: Callable | None = None,
 ) -> None:
+    """Export or print(log) auxiliary information such as 1D tof distribution.
+
+    The auxiliary output can be configured by `aux_config`(`AuxiliaryOutputConfig`).
+    `output_config`(`OutputConfig`) is only needed when the auxiliary output
+    should be stored in the `NXlauetof` file.
+    """
     output_dir.mkdir(exist_ok=True)
+    # TOF 1D distribution for all panels
     tof_histogram = sc.reduce(
         det_res.data.sum(["x_pixel_offset", "y_pixel_offset"])
         for det_res in results.instrument.detectors.values()
         if isinstance(det_res.data, sc.DataArray)
     ).sum()
+
+    # Export TOF 1D distribution into entry/aux
     if (
-        isinstance(tof_histogram, sc.DataArray)
+        output_config
+        and isinstance(tof_histogram, sc.DataArray)
         and not output_config.skip_file_output
-        and not output_config.no_tof_histogram
+        and not aux_config.no_tof_1d_in_file
     ):
         from .nexus import export_tof_distribution_nxlauetof
 
@@ -396,14 +406,16 @@ def save_auxiliary_output(
             tof_histogram=tof_histogram,
             output_file=output_config.output_file,
         )
-
+    # Export TOF 1D plot
     if isinstance(tof_histogram, sc.DataArray) and not aux_config.no_png:
         tof_histogram.plot(
             title="Tof Distribution (All Panels Summed)",
             grid=True,
         ).save(output_dir / aux_config.tof_1d_png_filename)
+    # Print(log) TOF 1D plot
     if (
         isinstance(tof_histogram, sc.DataArray)
+        and output_config
         and output_config.verbose
         and display is not None
     ):

--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -19,6 +19,7 @@ from ._executable_helper import (
     reduction_config_from_args,
 )
 from .configurations import (
+    AuxilaryOutputConfig,
     OutputConfig,
     ReductionConfig,
     TimeBinCoordinate,
@@ -237,6 +238,8 @@ def reduction(
     # Check the file output configuration before we start heavy computation.
     if not config.output.skip_file_output:
         _check_file(config.output.output_file, config.output.overwrite)
+    elif not (config.output.skip_file_output or config.aux.no_axilaries):
+        config.aux.check_output_dir()
 
     display = _retrieve_display(logger, display)
     input_file_path = _retrieve_input_file(config.inputs.input_file).resolve()
@@ -244,6 +247,9 @@ def reduction(
 
     output_file_path = pathlib.Path(config.output.output_file).resolve()
     display(f"Output file: {output_file_path}")
+
+    auxilary_output_dir = config.aux.build_target_dir(output_file_path.as_posix())
+    display(f"Auxiliary output dir: {auxilary_output_dir}")
 
     detector_names = select_detector_names(detector_ids=config.inputs.detector_ids)
 
@@ -324,6 +330,14 @@ def reduction(
 
     if not config.output.skip_file_output:
         save_results(results=results, output_config=config.output)
+        if not config.aux.no_axilaries:
+            save_plots(
+                results=results,
+                output_config=config.output,
+                aux_config=config.aux,
+                output_dir=auxilary_output_dir,
+                display=display,
+            )
 
     return results
 
@@ -355,6 +369,62 @@ def save_results(*, results: NMXLauetof, output_config: OutputConfig) -> None:
             )
         else:
             raise ValueError(f"Detector counts histogram missing in {detector_name}")
+
+
+def save_plots(
+    *,
+    results: NMXLauetof,
+    output_config: OutputConfig,
+    aux_config: AuxilaryOutputConfig,
+    output_dir: pathlib.Path,
+    display: Callable | None = None,
+) -> None:
+    output_dir.mkdir(exist_ok=True)
+    tof_histogram = sc.reduce(
+        det_res.data.sum(["x_pixel_offset", "y_pixel_offset"])
+        for det_res in results.instrument.detectors.values()
+        if isinstance(det_res.data, sc.DataArray)
+    ).sum()
+    if isinstance(tof_histogram, sc.DataArray) and not aux_config.no_png:
+        tof_histogram.plot(
+            title="Tof Distribution (All Panels Summed)",
+            grid=True,
+        ).save(output_dir / aux_config.tof_1d_png_filename)
+    if (
+        isinstance(tof_histogram, sc.DataArray)
+        and output_config.verbose
+        and display is not None
+    ):
+        da = tof_histogram
+        t_dim = da.dim
+        n_row = min(da.sizes[t_dim] // 4, 50)
+        max_value = da.max().value
+        row_size = int(max_value // n_row)
+        bars = [
+            list(("*" * int(val // row_size)).rjust(n_row)) for val in da.data.values
+        ]
+        bars = [
+            [bars[col_i][row_i] for col_i in range(len(bars))]
+            for row_i in range(len(bars[0]))
+        ]
+        bars = "\n".join("".join(c for c in row) for row in bars)
+
+        y_axis = f"max-count: {max_value} [{da.unit}]".ljust(da.sizes[t_dim], '-')
+        bars = y_axis + "\n" + bars
+        display(
+            "\n┌──TOF DISTRIBUTION (ALL PANELS SUMMED)".ljust(da.sizes[t_dim] + 2, '─')
+        )
+        bars = "\n".join('│' + row for row in bars.split("\n"))
+        if t_dim in da.coords:
+            t_coord = da.coords[t_dim]
+            t_unit = str(t_coord.unit)
+            t_min, t_max = int(t_coord.min().value), int(t_coord.max().value)
+            xaxis = f"{t_min:.3g} [{t_unit}]".ljust(da.sizes[t_dim])
+            max_t_label = f"{t_max:.3g} [{t_unit}]"
+            xaxis = xaxis[:-10] + max_t_label
+            bars += f"\n{xaxis} ({da.sizes[t_dim]} {t_dim} bins)"
+        bars += "\n└".ljust(da.sizes[t_dim] + 2, '─')
+        display(bars)
 
 
 def main() -> None:

--- a/packages/essnmx/src/ess/nmx/nexus.py
+++ b/packages/essnmx/src/ess/nmx/nexus.py
@@ -323,3 +323,29 @@ def export_reduced_data_as_nxlauetof(
             root_entry=nx_detector,
             var=da.coords[time_coord_name],
         )
+
+
+def export_tof_distribution_nxlauetof(
+    tof_histogram: sc.DataArray,
+    output_file: str | pathlib.Path | io.BytesIO,
+    append_mode: bool = True,
+) -> None:
+    """Export Tof Distribution to a NeXus file.
+
+    Parameters
+    ----------
+    tof_histogram:
+        Tof 1D histogram.
+    output_file:
+        Output file path.
+
+    """
+
+    if not append_mode:
+        raise NotImplementedError("Only append mode is supported for now.")
+
+    with h5py.File(output_file, "r+") as f:
+        nx_instrument: h5py.Group = f["entry/instrument"]
+        _create_dataset_from_var(
+            root_entry=nx_instrument, name="tof-1d", var=tof_histogram.data, dtype=int
+        )

--- a/packages/essnmx/src/ess/nmx/nexus.py
+++ b/packages/essnmx/src/ess/nmx/nexus.py
@@ -345,7 +345,17 @@ def export_tof_distribution_nxlauetof(
         raise NotImplementedError("Only append mode is supported for now.")
 
     with h5py.File(output_file, "r+") as f:
-        nx_instrument: h5py.Group = f["entry/instrument"]
+        auxiliary_group: h5py.Group = f['entry'].create_group(name="aux")
+        tof1d_group = snx.create_class(
+            group=auxiliary_group, nx_class=snx.NXdata, name='tof-1d'
+        )
+        tof1d_group.attrs['axes'] = tof_histogram.dims
+        tof1d_group.attrs['signal'] = 'data'
         _create_dataset_from_var(
-            root_entry=nx_instrument, name="tof-1d", var=tof_histogram.data, dtype=int
+            root_entry=tof1d_group,
+            name=tof_histogram.dim,
+            var=tof_histogram.coords[tof_histogram.dim],
+        )
+        _create_dataset_from_var(
+            root_entry=tof1d_group, name="data", var=tof_histogram.data, dtype=int
         )

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -15,8 +15,12 @@ import bitshuffle.h5  # noqa: F401
 import h5py
 import numpy as np
 import pytest
+import scipp as sc
+import scippnexus as snx
+from scipp.testing import assert_identical
 
 from ess.nmx.configurations import (
+    AuxiliaryOutputConfig,
     InputConfig,
     OutputConfig,
     ReductionConfig,
@@ -94,6 +98,7 @@ def test_compare_output_file_with_frozen(tmp_path: pathlib.Path):
             output_file=output_file.as_posix(),
             compression=Compression.NONE,
             skip_file_output=False,
+            # Auxiliary output does not need to be part of the regression tests.
         ),
     )
     with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
@@ -107,3 +112,66 @@ def test_compare_output_file_with_frozen(tmp_path: pathlib.Path):
     with h5py.File(output_file) as cur_file:
         with h5py.File(ref_file_path) as reference_file:
             assert_h5obj_equal(reference_file, cur_file, excluded_paths=excluded_paths)
+
+
+def test_auxiliary_output(tmp_path: pathlib.Path):
+    """Test that the executable runs and returns the expected output."""
+
+    # Make a new output file from current implementation.
+    input_file = get_small_nmx_nexus()
+    output_file = tmp_path / "scipp_output_with_auxiliary.h5"
+    assert not output_file.exists()
+    config = ReductionConfig(
+        inputs=InputConfig(input_file=[input_file.as_posix()]),
+        workflow=WorkflowConfig(),
+        output=OutputConfig(
+            output_file=output_file.as_posix(),
+            compression=Compression.NONE,
+            skip_file_output=False,
+        ),
+        aux=AuxiliaryOutputConfig(no_png=False, no_tof_1d_in_file=False),
+    )
+    with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
+        results = reduction(config=config)
+
+    # Test PNG file.
+    expected_png_file_path = (
+        tmp_path / "scipp_output_with_auxiliary" / "essnmx-reduce-tof-1d.png"
+    )
+    assert expected_png_file_path.exists()
+    tof1d_path = "/entry/aux/tof-1d"
+    tof1d_saved: sc.Variable = snx.load(filename=output_file, root=tof1d_path)
+    tof1d_computed = sc.reduce(
+        det_res.data.sum(["x_pixel_offset", "y_pixel_offset"])
+        for det_res in results.instrument.detectors.values()
+        if isinstance(det_res.data, sc.DataArray)
+    ).sum()
+
+    assert_identical(tof1d_saved, tof1d_computed)
+
+
+def test_auxiliary_output_dir_not_made_if_not_needed(tmp_path: pathlib.Path):
+    """Test that the executable runs and returns the expected output."""
+
+    # Make a new output file from current implementation.
+    input_file = get_small_nmx_nexus()
+    output_file = tmp_path / "scipp_output_with_auxiliary.h5"
+    assert not output_file.exists()
+    config = ReductionConfig(
+        inputs=InputConfig(input_file=[input_file.as_posix()]),
+        workflow=WorkflowConfig(nbins=2),
+        output=OutputConfig(
+            output_file=output_file.as_posix(),
+            compression=Compression.NONE,
+            skip_file_output=False,
+        ),
+        aux=AuxiliaryOutputConfig(no_png=True, no_tof_1d_in_file=True),
+    )
+    with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
+        _ = reduction(config=config)
+
+    assert config.aux.no_axilaries
+    assert output_file.exists()
+    assert len(tuple(output_file.parent.iterdir())) == 1
+    with h5py.File(output_file) as f:
+        assert "entry/aux" not in f

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -134,7 +134,7 @@ def test_auxiliary_output(tmp_path: pathlib.Path):
     with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
         results = reduction(config=config)
 
-    # Test PNG file.
+    # Test if the PNG file is generated.
     expected_png_file_path = (
         tmp_path / "scipp_output_with_auxiliary" / "essnmx-reduce-tof-1d.png"
     )

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -20,7 +20,6 @@ import scippnexus as snx
 from scipp.testing import assert_identical
 
 from ess.nmx.configurations import (
-    AuxiliaryOutputConfig,
     InputConfig,
     OutputConfig,
     ReductionConfig,
@@ -107,6 +106,7 @@ def test_compare_output_file_with_frozen(tmp_path: pathlib.Path):
     entry_path = pathlib.Path('/entry')
     excluded_paths = (
         entry_path / 'reducer/program',  # version should be different
+        entry_path / 'aux',  # downstream sw must not depend on the auxiliary output
     )
     ref_file_path = get_small_nmx_reduced()
     with h5py.File(output_file) as cur_file:
@@ -129,7 +129,6 @@ def test_auxiliary_output(tmp_path: pathlib.Path):
             compression=Compression.NONE,
             skip_file_output=False,
         ),
-        aux=AuxiliaryOutputConfig(no_png=False, no_tof_1d_in_file=False),
     )
     with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
         results = reduction(config=config)
@@ -148,30 +147,3 @@ def test_auxiliary_output(tmp_path: pathlib.Path):
     ).sum()
 
     assert_identical(tof1d_saved, tof1d_computed)
-
-
-def test_auxiliary_output_dir_not_made_if_not_needed(tmp_path: pathlib.Path):
-    """Test that the executable runs and returns the expected output."""
-
-    # Make a new output file from current implementation.
-    input_file = get_small_nmx_nexus()
-    output_file = tmp_path / "scipp_output_with_auxiliary.h5"
-    assert not output_file.exists()
-    config = ReductionConfig(
-        inputs=InputConfig(input_file=[input_file.as_posix()]),
-        workflow=WorkflowConfig(nbins=2),
-        output=OutputConfig(
-            output_file=output_file.as_posix(),
-            compression=Compression.NONE,
-            skip_file_output=False,
-        ),
-        aux=AuxiliaryOutputConfig(no_png=True, no_tof_1d_in_file=True),
-    )
-    with pytest.warns(RuntimeWarning, match="No crystal rotation*"):
-        _ = reduction(config=config)
-
-    assert config.aux.no_axilaries
-    assert output_file.exists()
-    assert len(tuple(output_file.parent.iterdir())) == 1
-    with h5py.File(output_file) as f:
-        assert "entry/aux" not in f

--- a/packages/essnmx/tests/executable_test.py
+++ b/packages/essnmx/tests/executable_test.py
@@ -15,14 +15,19 @@ import scippnexus as snx
 from scipp.testing import assert_identical
 
 from ess.nmx._executable_helper import (
-    InputConfig,
-    OutputConfig,
-    ReductionConfig,
-    WorkflowConfig,
     build_reduction_argument_parser,
     reduction_config_from_args,
 )
-from ess.nmx.configurations import TimeBinCoordinate, TimeBinUnit, to_command_arguments
+from ess.nmx.configurations import (
+    AuxilaryOutputConfig,
+    InputConfig,
+    OutputConfig,
+    ReductionConfig,
+    TimeBinCoordinate,
+    TimeBinUnit,
+    WorkflowConfig,
+    to_command_arguments,
+)
 from ess.nmx.executables import reduction
 from ess.nmx.types import Compression, NMXLauetof
 
@@ -55,6 +60,7 @@ def _default_config() -> ReductionConfig:
         inputs=InputConfig(input_file=['']),
         workflow=WorkflowConfig(),
         output=OutputConfig(),
+        aux=AuxilaryOutputConfig(),
     )
 
 
@@ -109,16 +115,21 @@ def test_reduction_config() -> None:
         verbose=True,
         skip_file_output=True,
         overwrite=True,
+        no_tof_histogram=True,
     )
+    auxilary_options = AuxilaryOutputConfig(output_dir='test-aux-output', no_png=True)
     expected_config = ReductionConfig(
-        inputs=input_options, workflow=workflow_options, output=output_options
+        inputs=input_options,
+        workflow=workflow_options,
+        output=output_options,
+        aux=auxilary_options,
     )
     # Check if all values are non-default.
     _check_non_default_config(expected_config)
 
     # Build argument list manually, not using `to_command_arguments` to test it.
     arg_list = _build_arg_list_from_pydantic_instance(
-        input_options, workflow_options, output_options
+        input_options, workflow_options, output_options, auxilary_options
     )
     assert arg_list == to_command_arguments(config=expected_config, one_line=False)
 

--- a/packages/essnmx/tests/executable_test.py
+++ b/packages/essnmx/tests/executable_test.py
@@ -116,9 +116,7 @@ def test_reduction_config() -> None:
         skip_file_output=True,
         overwrite=True,
     )
-    auxilary_options = AuxiliaryOutputConfig(
-        output_dir='test-aux-output', no_png=True, no_tof_1d_in_file=True
-    )
+    auxilary_options = AuxiliaryOutputConfig(output_dir='test-aux-output')
     expected_config = ReductionConfig(
         inputs=input_options,
         workflow=workflow_options,

--- a/packages/essnmx/tests/executable_test.py
+++ b/packages/essnmx/tests/executable_test.py
@@ -115,9 +115,10 @@ def test_reduction_config() -> None:
         verbose=True,
         skip_file_output=True,
         overwrite=True,
-        no_tof_histogram=True,
     )
-    auxilary_options = AuxiliaryOutputConfig(output_dir='test-aux-output', no_png=True)
+    auxilary_options = AuxiliaryOutputConfig(
+        output_dir='test-aux-output', no_png=True, no_tof_1d_in_file=True
+    )
     expected_config = ReductionConfig(
         inputs=input_options,
         workflow=workflow_options,

--- a/packages/essnmx/tests/executable_test.py
+++ b/packages/essnmx/tests/executable_test.py
@@ -19,7 +19,7 @@ from ess.nmx._executable_helper import (
     reduction_config_from_args,
 )
 from ess.nmx.configurations import (
-    AuxilaryOutputConfig,
+    AuxiliaryOutputConfig,
     InputConfig,
     OutputConfig,
     ReductionConfig,
@@ -60,7 +60,7 @@ def _default_config() -> ReductionConfig:
         inputs=InputConfig(input_file=['']),
         workflow=WorkflowConfig(),
         output=OutputConfig(),
-        aux=AuxilaryOutputConfig(),
+        aux=AuxiliaryOutputConfig(),
     )
 
 
@@ -117,7 +117,7 @@ def test_reduction_config() -> None:
         overwrite=True,
         no_tof_histogram=True,
     )
-    auxilary_options = AuxilaryOutputConfig(output_dir='test-aux-output', no_png=True)
+    auxilary_options = AuxiliaryOutputConfig(output_dir='test-aux-output', no_png=True)
     expected_config = ReductionConfig(
         inputs=input_options,
         workflow=workflow_options,

--- a/packages/essnmx/tests/nxlauetof_io_helper_test.py
+++ b/packages/essnmx/tests/nxlauetof_io_helper_test.py
@@ -7,7 +7,12 @@ import pytest
 from scipp.testing.assertions import assert_allclose, assert_identical
 
 from ess.nmx._nxlauetof_io import load_essnmx_nxlauetof
-from ess.nmx.configurations import InputConfig, OutputConfig, ReductionConfig
+from ess.nmx.configurations import (
+    AuxiliaryOutputConfig,
+    InputConfig,
+    OutputConfig,
+    ReductionConfig,
+)
 from ess.nmx.executables import reduction
 from ess.nmx.types import Compression
 
@@ -30,7 +35,8 @@ def reduction_config(temp_output_file: pathlib.Path) -> ReductionConfig:
         compression=Compression.NONE,
         skip_file_output=False,
     )
-    return ReductionConfig(inputs=input_config, output=output_config)
+    aux_config = AuxiliaryOutputConfig(no_tof_1d_in_file=True, no_png=True)
+    return ReductionConfig(inputs=input_config, output=output_config, aux=aux_config)
 
 
 @contextmanager

--- a/packages/essnmx/tests/nxlauetof_io_helper_test.py
+++ b/packages/essnmx/tests/nxlauetof_io_helper_test.py
@@ -8,7 +8,6 @@ from scipp.testing.assertions import assert_allclose, assert_identical
 
 from ess.nmx._nxlauetof_io import load_essnmx_nxlauetof
 from ess.nmx.configurations import (
-    AuxiliaryOutputConfig,
     InputConfig,
     OutputConfig,
     ReductionConfig,
@@ -35,8 +34,7 @@ def reduction_config(temp_output_file: pathlib.Path) -> ReductionConfig:
         compression=Compression.NONE,
         skip_file_output=False,
     )
-    aux_config = AuxiliaryOutputConfig(no_tof_1d_in_file=True, no_png=True)
-    return ReductionConfig(inputs=input_config, output=output_config, aux=aux_config)
+    return ReductionConfig(inputs=input_config, output=output_config)
 
 
 @contextmanager


### PR DESCRIPTION
Fixes #267

Command to test:
```
pixi run --frozen essnmx-reduce \
    --output-dir aux \
    --input-file ${HOME}/.cache/ess/nmx/small_nmx_nexus.hdf.zip.unzip/small_nmx_nexus.hdf \
    --output-file test.hdf \
    --overwrite --nbins 50
```

Then it should save png file in the `aux/` directory and `test.hdf` should have `/entry/aux/tof-1d`.