### PR TITLE
Move dask to optional/test dependencies

### DIFF
--- a/packages/essdiffraction/pyproject.toml
+++ b/packages/essdiffraction/pyproject.toml
@@ -29,25 +29,25 @@ requires-python = ">=3.11"
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
-  "dask>=2022.1.0",
-  "essreduce>=26.4.0",
-  "graphviz",
-  "numpy>=2",
-  "plopp>=26.2.0",
-  "pythreejs>=2.4.1",
-  "sciline>=25.04.1",
-  "scipp>=25.11.0",
-  "scippneutron>=26.3.0",
-  "scippnexus>=23.12.0",
-  "tof>=25.12.0",
-  "ncrystal[cif]>=4.1.0",
-  "spglib!=2.7",  # https://github.com/mctools/ncrystal/issues/320
+    "essreduce>=26.4.0",
+    "graphviz",
+    "numpy>=2",
+    "plopp>=26.2.0",
+    "pythreejs>=2.4.1",
+    "sciline>=25.04.1",
+    "scipp>=25.11.0",
+    "scippneutron>=26.3.0",
+    "scippnexus>=23.12.0",
+    "tof>=25.12.0",
+    "ncrystal[cif]>=4.1.0",
+    "spglib!=2.7",  # https://github.com/mctools/ncrystal/issues/320
 ]
 
 dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "pandas>=2.1.2",
     "pooch>=1.5",
     "pytest>=7.0",

--- a/packages/essimaging/pyproject.toml
+++ b/packages/essimaging/pyproject.toml
@@ -30,20 +30,20 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 
 dependencies = [
-  "dask>=2022.1.0",
-  "graphviz",
-  "plopp[all]>=23.10.0",
-  "sciline>=23.9.1",
-  "scipp>=25.4.0",
-  "scippneutron>=24.12.0",
-  "scippnexus>=23.11.1",
-  "tifffile>=2024.7.2",
-  "essreduce>=26.4.0",
-  "scitiff>=25.7",
+    "graphviz",
+    "plopp[all]>=23.10.0",
+    "sciline>=23.9.1",
+    "scipp>=25.4.0",
+    "scippneutron>=24.12.0",
+    "scippnexus>=23.11.1",
+    "tifffile>=2024.7.2",
+    "essreduce>=26.4.0",
+    "scitiff>=25.7",
 ]
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "pytest>=8.0",
     "pooch>=1.5",
     "tof>=25.08.0",

--- a/packages/essnmx/pyproject.toml
+++ b/packages/essnmx/pyproject.toml
@@ -30,21 +30,20 @@ requires-python = ">=3.11"
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
-  "dask>=2022.1.0",
-  "essreduce>=26.4.0",
-  "graphviz",
-  "plopp>=24.7.0",
-  "sciline>=24.06.0",
-  "scipp>=25.3.0",
-  "scippnexus>=23.12.0",
-  "scippneutron>=26.03.0",
-  "pooch>=1.5",
-  "pandas>=2.1.2",
-  "gemmi>=0.6.6",
-  "defusedxml>=0.7.1",
-  "msgpack>=1.0.8",
-  "tof>=25.12.1",
-  "numpy>=2.0.0",
+    "essreduce>=26.4.0",
+    "graphviz",
+    "plopp>=24.7.0",
+    "sciline>=24.06.0",
+    "scipp>=25.3.0",
+    "scippnexus>=23.12.0",
+    "scippneutron>=26.03.0",
+    "pooch>=1.5",
+    "pandas>=2.1.2",
+    "gemmi>=0.6.6",
+    "defusedxml>=0.7.1",
+    "msgpack>=1.0.8",
+    "tof>=25.12.1",
+    "numpy>=2.0.0",
 ]
 
 dynamic = ["version"]
@@ -55,22 +54,23 @@ essnmx-reduce = "ess.nmx.executables:main"
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "pytest>=8.0",
     "bitshuffle>=0.5.2;os_name == 'posix'",
 ]
 docs = [
-  "autodoc-pydantic",
-  "ipykernel",
-  "ipython!=8.7.0", # Breaks syntax highlighting in Jupyter code cells.
-  "myst-parser",
-  "nbsphinx",
-  "pydata-sphinx-theme>=0.14",
-  "sphinx<9.0.0",
-  "sphinx-autodoc-typehints",
-  "sphinx-copybutton",
-  "sphinx-design",
-  "pythreejs", # For instrument view.
-  "scippneutron",
+    "autodoc-pydantic",
+    "ipykernel",
+    "ipython!=8.7.0", # Breaks syntax highlighting in Jupyter code cells.
+    "myst-parser",
+    "nbsphinx",
+    "pydata-sphinx-theme>=0.14",
+    "sphinx<9.0.0",
+    "sphinx-autodoc-typehints",
+    "sphinx-copybutton",
+    "sphinx-design",
+    "pythreejs", # For instrument view.
+    "scippneutron",
 ]
 
 [project.urls]

--- a/packages/essreduce/pyproject.toml
+++ b/packages/essreduce/pyproject.toml
@@ -30,7 +30,6 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 
 dependencies = [
-    "dask>=2022.1.0",
     "graphviz>=0.20",
     "sciline>=25.11.0",
     "scipp>=26.3.1",
@@ -41,6 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "ipywidgets>=8.1",
     "matplotlib>=3.10.7",
     "numba>=0.63",

--- a/packages/essreflectometry/pyproject.toml
+++ b/packages/essreflectometry/pyproject.toml
@@ -29,7 +29,6 @@ requires-python = ">=3.11"
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
-    "dask>=2022.1.0",
     "python-dateutil",
     "graphviz",
     "plopp>=24.7.0",
@@ -47,6 +46,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "pytest>=7.0",
     "pooch>=1.5",
 ]

--- a/packages/esssans/pyproject.toml
+++ b/packages/esssans/pyproject.toml
@@ -30,21 +30,21 @@ requires-python = ">=3.11"
 dynamic = ["version"]
 
 dependencies = [
-  "dask>=2022.1.0",
-  "graphviz>=0.20",
-  "essreduce>=26.4.0",
-  "numpy>=1.26.4",
-  "pandas>=2.1.2",
-  "plopp>=25.10.0",
-  "pythreejs>=2.4.1",
-  "sciline>=25.08.0",
-  "scipp>=24.09.1",  # Fixed new hist/bin API
-  "scippneutron>=25.02.1",
-  "scippnexus>=23.12.1",  # 23.12.0 and below deadlock in threaded use
+    "graphviz>=0.20",
+    "essreduce>=26.4.0",
+    "numpy>=1.26.4",
+    "pandas>=2.1.2",
+    "plopp>=25.10.0",
+    "pythreejs>=2.4.1",
+    "sciline>=25.08.0",
+    "scipp>=24.09.1",  # Fixed new hist/bin API
+    "scippneutron>=25.02.1",
+    "scippnexus>=23.12.1",  # 23.12.0 and below deadlock in threaded use
 ]
 
 [project.optional-dependencies]
 test = [
+    "dask>=2022.1.0",
     "ipympl>=0.9.4",
     "pytest>=7.0",
     "pooch>=1.5",


### PR DESCRIPTION
Move Dask to be an optional dependency.

There is a naive scheduler in Sciline which doesn't need Dask, and Dask pulls in many dependencies which is not always desirable.

That said, the Dask scheduler is smarter and manages memory better, so Dask should probably be installed on any reduction environment anyway.

I also standardized indentation in the pyproject files.