### PR TITLE
[CI] More efficient nightly environment setup.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-tags: true
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
           pixi-version: v0.68.0
@@ -53,11 +53,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-tags: true
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.21"
           python-version: "3.11"
+          cache-suffix: ${{ matrix.package }}
       - name: Test with lowest direct dependencies
         working-directory: packages/${{ matrix.package }}
         run: uv run --extra=test --resolution=lowest-direct pytest
@@ -79,11 +80,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-tags: true
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.7.21"
           python-version: "3.11"
+          cache-suffix: ${{ matrix.package }}
       - name: Test with latest dependencies
         working-directory: packages/${{ matrix.package }}
         run: uv run --extra=test --resolution=highest pytest


### PR DESCRIPTION
1. checkout with tags not all branches
2. specify cache-suffix in the setup uv phase cause the action was complaining about the conflicting cache key...