### PR TITLE
[ESSSPECTROSCOPY] Default BIFROST detector names

### DIFF
--- a/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-make-wavelength-lookup-table.ipynb
+++ b/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-make-wavelength-lookup-table.ipynb
@@ -53,20 +53,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_filename = simulated_elastic_incoherent_with_phonon()\n",
-    "with snx.File(input_filename) as f:\n",
-    "    detector_names = list(f['entry/instrument'][snx.NXdetector])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bifrost_workflow = BifrostSimulationWorkflow(detector_names)\n",
-    "bifrost_workflow[Filename[SampleRun]] = input_filename\n",
+    "bifrost_workflow = BifrostSimulationWorkflow()\n",
+    "bifrost_workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()\n",
     "\n",
     "M = nexus.types.EmptyMonitor[SampleRun, NormalizationMonitor]\n",
     "C = RawChoppers[SampleRun]\n",
@@ -78,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "4",
    "metadata": {},
    "source": [
     "Compute the required distance range to include the monitor and all detectors.\n",
@@ -89,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +94,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "6",
    "metadata": {},
    "source": [
     "The choppers in the simulated file need to be processed before they can be used for computing a lookup table.\n",
@@ -116,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +130,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "8",
    "metadata": {},
    "source": [
     "## Compute the lookup table"
@@ -150,7 +138,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "source": [
     "Construct a lookup table workflow:"
@@ -159,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "source": [
     "Compute a lookup table:"
@@ -193,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Save to file"
@@ -222,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-reduction.ipynb
+++ b/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-reduction.ipynb
@@ -21,7 +21,6 @@
     "import numpy as np\n",
     "import scipp as sc\n",
     "import sciline\n",
-    "import scippnexus as snx\n",
     "\n",
     "from ess import bifrost\n",
     "from ess.bifrost.data import (\n",
@@ -36,9 +35,8 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "BIFROST NeXus files store detector data in 45 separate NXdetector groups, one per detector triplet.\n",
-    "For the time being, we need to specify the names of these NXdetector groups when creating the workflow.\n",
-    "So load them from the input file:"
+    "Construct the workflow which is a [sciline.Pipeline](https://scipp.github.io/sciline/generated/classes/sciline.Pipeline.html) and encodes the entire reduction procedure.\n",
+    "We need to provide a couple of parameters so we can run the workflow:"
    ]
   },
   {
@@ -48,46 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with snx.File(simulated_elastic_incoherent_with_phonon()) as f:\n",
-    "    detector_names = list(f['entry/instrument'][snx.NXdetector])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4",
-   "metadata": {},
-   "source": [
-    "Generally, we would use all triplets, but for this example, we only use the first two.\n",
-    "This reduces the size of the data and the time to compute it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "detector_names = detector_names[:2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6",
-   "metadata": {},
-   "source": [
-    "Next, construct the workflow which is a [sciline.Pipeline](https://scipp.github.io/sciline/generated/classes/sciline.Pipeline.html) and encodes the entire reduction procedure.\n",
-    "We need to provide a couple of parameters so we can run the workflow:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "workflow = bifrost.BifrostSimulationWorkflow(detector_names)\n",
+    "workflow = bifrost.BifrostSimulationWorkflow()\n",
     "# Set the input file name:\n",
     "workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()\n",
     "# Set the lookup table for frame unwrapping:\n",
@@ -107,7 +66,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "4",
    "metadata": {},
    "source": [
     "Next, draw the workflow as a graph to inspect the steps it will take to reduce the data.\n",
@@ -119,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "6",
    "metadata": {},
    "source": [
     "We are ready to compute the reduced data.\n",
@@ -139,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "8",
    "metadata": {},
    "source": [
     "The result contains coordinates for the sample table and detector rotation angles `a3` and `a4`, respectively.\n",
@@ -159,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "10",
    "metadata": {},
    "source": [
     "We can plot the counts as a function of energy transfer and $a_3$ by removing the unused dimensions.\n",
@@ -178,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "12",
    "metadata": {},
    "source": [
     "We can also plot the counts as a function of the momentum transfer in the sample table frame $Q$.\n",
@@ -207,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/packages/essspectroscopy/src/ess/bifrost/__init__.py
+++ b/packages/essspectroscopy/src/ess/bifrost/__init__.py
@@ -5,7 +5,6 @@
 
 import importlib.metadata
 
-from .detector import providers
 from .io import nexus
 from .workflow import BifrostSimulationWorkflow, BifrostWorkflow
 
@@ -16,4 +15,4 @@ except importlib.metadata.PackageNotFoundError:
 
 del importlib
 
-__all__ = ['BifrostSimulationWorkflow', 'BifrostWorkflow', 'nexus', 'providers']
+__all__ = ['BifrostSimulationWorkflow', 'BifrostWorkflow', 'nexus']

--- a/packages/essspectroscopy/src/ess/bifrost/__init__.py
+++ b/packages/essspectroscopy/src/ess/bifrost/__init__.py
@@ -5,6 +5,7 @@
 
 import importlib.metadata
 
+from .detector import detector_names
 from .io import nexus
 from .workflow import BifrostSimulationWorkflow, BifrostWorkflow
 
@@ -15,4 +16,4 @@ except importlib.metadata.PackageNotFoundError:
 
 del importlib
 
-__all__ = ['BifrostSimulationWorkflow', 'BifrostWorkflow', 'nexus']
+__all__ = ['BifrostSimulationWorkflow', 'BifrostWorkflow', 'detector_names', 'nexus']

--- a/packages/essspectroscopy/src/ess/bifrost/__init__.py
+++ b/packages/essspectroscopy/src/ess/bifrost/__init__.py
@@ -5,7 +5,7 @@
 
 import importlib.metadata
 
-from .detector import detector_names
+from .detector import default_detector_names
 from .io import nexus
 from .workflow import BifrostSimulationWorkflow, BifrostWorkflow
 
@@ -16,4 +16,9 @@ except importlib.metadata.PackageNotFoundError:
 
 del importlib
 
-__all__ = ['BifrostSimulationWorkflow', 'BifrostWorkflow', 'detector_names', 'nexus']
+__all__ = [
+    'BifrostSimulationWorkflow',
+    'BifrostWorkflow',
+    'default_detector_names',
+    'nexus',
+]

--- a/packages/essspectroscopy/src/ess/bifrost/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/detector.py
@@ -282,7 +282,7 @@ def merge_triplets(
     return concatenated
 
 
-def detector_names() -> list[str]:
+def default_detector_names() -> list[str]:
     """Return the list of detector names in a BIFROST NeXus file.
 
     These names are based on the names in the NeXus schema.

--- a/packages/essspectroscopy/src/ess/bifrost/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/detector.py
@@ -3,6 +3,7 @@
 
 """Detector handling for BIFROST."""
 
+import itertools
 from collections.abc import Callable
 
 import scipp as sc
@@ -279,6 +280,19 @@ def merge_triplets(
 
     # Fall back to simple concatenation if not a regular grid
     return concatenated
+
+
+def detector_names() -> list[str]:
+    """Return the list of detector names in a BIFROST NeXus file.
+
+    These names are based on the names in the NeXus schema.
+    """
+    # c is the channel number
+    # a is the arc number
+    return [
+        f"channel_{c}_{a}_triplet"
+        for c, a in itertools.product(range(1, 10), range(1, 6))
+    ]
 
 
 providers = (arc_number, get_calibrated_detector_bifrost)

--- a/packages/essspectroscopy/src/ess/bifrost/live.py
+++ b/packages/essspectroscopy/src/ess/bifrost/live.py
@@ -9,11 +9,7 @@ from typing import NewType
 
 import sciline
 import scipp as sc
-from ess.spectroscopy.types import (
-    EnergyQDetector,
-    NeXusDetectorName,
-    RunType,
-)
+from ess.spectroscopy.types import EnergyQDetector, RunType
 
 from .types import ArcEnergy
 from .workflow import BifrostWorkflow
@@ -170,9 +166,9 @@ def cut(
     )
 
 
-def BifrostQCutWorkflow(detector_names: list[NeXusDetectorName]) -> sciline.Pipeline:
+def BifrostQCutWorkflow(detector_names: list[str] | None = None) -> sciline.Pipeline:
     """Workflow for BIFROST to compute cuts in Q-E-space."""
-    workflow = BifrostWorkflow(detector_names)
+    workflow = BifrostWorkflow(detector_names=detector_names)
     workflow.insert(arc_energy)
     workflow.insert(cut)
     return workflow

--- a/packages/essspectroscopy/src/ess/bifrost/workflow.py
+++ b/packages/essspectroscopy/src/ess/bifrost/workflow.py
@@ -29,8 +29,7 @@ from ess.spectroscopy.types import (
 from scippnexus import NXdetector
 
 from .cutting import providers as cutting_providers
-from .detector import detector_names as default_detector_names
-from .detector import merge_triplets
+from .detector import default_detector_names, merge_triplets
 from .detector import providers as detector_providers
 from .io import mcstas, nexus
 from .normalization import providers as normalisation_providers

--- a/packages/essspectroscopy/src/ess/bifrost/workflow.py
+++ b/packages/essspectroscopy/src/ess/bifrost/workflow.py
@@ -29,6 +29,7 @@ from ess.spectroscopy.types import (
 from scippnexus import NXdetector
 
 from .cutting import providers as cutting_providers
+from .detector import detector_names as default_detector_names
 from .detector import merge_triplets
 from .detector import providers as detector_providers
 from .io import mcstas, nexus
@@ -79,7 +80,8 @@ _SIMULATION_PROVIDERS = (
 
 
 def BifrostSimulationWorkflow(
-    detector_names: list[NeXusDetectorName],
+    *,
+    detector_names: list[str] | None = None,
 ) -> sciline.Pipeline:
     """Data reduction workflow for simulated BIFROST data.
 
@@ -87,6 +89,7 @@ def BifrostSimulationWorkflow(
     ----------
     detector_names:
         Names of ``NXdetector`` groups in the input NeXus file.
+        If ``Nonw``, all detector will be processed and merged.
 
     Returns
     -------
@@ -117,9 +120,21 @@ def BifrostSimulationWorkflow(
 
 
 def BifrostWorkflow(
-    detector_names: list[NeXusDetectorName],
+    *,
+    detector_names: list[str] | None = None,
 ) -> sciline.Pipeline:
-    """Data reduction workflow for BIFROST."""
+    """Data reduction workflow for BIFROST.
+
+    Parameters
+    ----------
+    detector_names:
+        Names of ``NXdetector`` groups in the input NeXus file.
+        If ``Nonw``, all detector will be processed and merged.
+
+    Returns
+    -------
+    :
+        A pipeline for reducing simulated BIFROST data."""
     workflow = TofWorkflow(
         run_types=(SampleRun,),
         monitor_types=(
@@ -176,13 +191,13 @@ def concat_event_lists(
     return sc.concat(data, dim="event_time_zero")
 
 
-def _make_detector_name_mapping(detector_names: list[NeXusDetectorName]) -> Any:
+def _make_detector_name_mapping(detector_names: list[str] | None) -> Any:
+    names = detector_names if detector_names is not None else default_detector_names()
+
     # Use Pandas if possible to label the index.
     try:
         import pandas
 
-        return pandas.DataFrame({NeXusDetectorName: detector_names}).rename_axis(
-            index='triplet'
-        )
+        return pandas.DataFrame({NeXusDetectorName: names}).rename_axis(index='triplet')
     except ModuleNotFoundError:
-        return {NeXusDetectorName: detector_names}
+        return {NeXusDetectorName: names}

--- a/packages/essspectroscopy/tests/bifrost/cutting_test.py
+++ b/packages/essspectroscopy/tests/bifrost/cutting_test.py
@@ -23,7 +23,7 @@ from ess.spectroscopy.types import (
 @pytest.fixture
 def energy_data() -> EnergyQDetector[SampleRun]:
     workflow = bifrost.BifrostSimulationWorkflow(
-        detector_names=bifrost.detector_names()[:10]
+        detector_names=bifrost.default_detector_names()[:10]
     )
     workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()
     workflow[LookupTableFilename] = lookup_table_simulation()

--- a/packages/essspectroscopy/tests/bifrost/cutting_test.py
+++ b/packages/essspectroscopy/tests/bifrost/cutting_test.py
@@ -4,7 +4,6 @@ import numpy as np
 import pytest
 import scipp as sc
 import scipp.testing
-import scippnexus as snx
 from ess import bifrost
 from ess.bifrost.data import (
     lookup_table_simulation,
@@ -16,24 +15,16 @@ from ess.spectroscopy.types import (
     Filename,
     LookupTableFilename,
     LookupTableRelativeErrorThreshold,
-    NeXusDetectorName,
     SampleRun,
     UncertaintyBroadcastMode,
 )
 
 
-@pytest.fixture(scope='module')
-def simulation_detector_names() -> list[NeXusDetectorName]:
-    with snx.File(simulated_elastic_incoherent_with_phonon()) as f:
-        names = list(f['entry']['instrument'][snx.NXdetector].keys())
-    return names[:10]  # First 10 detectors form a 5x2 grid (arc=5, channel=2)
-
-
 @pytest.fixture
-def energy_data(
-    simulation_detector_names: list[NeXusDetectorName],
-) -> EnergyQDetector[SampleRun]:
-    workflow = bifrost.BifrostSimulationWorkflow(simulation_detector_names)
+def energy_data() -> EnergyQDetector[SampleRun]:
+    workflow = bifrost.BifrostSimulationWorkflow(
+        detector_names=bifrost.detector_names()[:10]
+    )
     workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()
     workflow[LookupTableFilename] = lookup_table_simulation()
     workflow[LookupTableRelativeErrorThreshold] = {

--- a/packages/essspectroscopy/tests/bifrost/io/sqw_test.py
+++ b/packages/essspectroscopy/tests/bifrost/io/sqw_test.py
@@ -17,7 +17,6 @@ import pytest
 import sciline
 import scipp as sc
 import scipp.testing
-import scippnexus as snx
 from ess import bifrost
 from ess.bifrost.data import (
     lookup_table_simulation,
@@ -53,10 +52,8 @@ N_PIXELS_PER_DETECTOR = 300  # Fixed, not a parameter!
 
 
 @pytest.fixture(scope='module')
-def detector_names() -> list[NeXusDetectorName]:
-    with snx.File(simulated_elastic_incoherent_with_phonon()) as f:
-        detector_names = list(f['entry/instrument'][snx.NXdetector])
-    return detector_names[:N_DETECTORS]
+def detector_names() -> list[str]:
+    return bifrost.detector_names()[:N_DETECTORS]
 
 
 @pytest.fixture(scope='module')
@@ -72,7 +69,7 @@ def sample() -> sqw.SqwIXSample:
 def common_workflow(
     detector_names: list[NeXusDetectorName], sample: sqw.SqwIXSample
 ) -> sciline.Pipeline:
-    wf = bifrost.BifrostSimulationWorkflow(detector_names)
+    wf = bifrost.BifrostSimulationWorkflow(detector_names=detector_names)
 
     wf[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()
     wf[LookupTableFilename] = lookup_table_simulation()

--- a/packages/essspectroscopy/tests/bifrost/io/sqw_test.py
+++ b/packages/essspectroscopy/tests/bifrost/io/sqw_test.py
@@ -53,7 +53,7 @@ N_PIXELS_PER_DETECTOR = 300  # Fixed, not a parameter!
 
 @pytest.fixture(scope='module')
 def detector_names() -> list[str]:
-    return bifrost.detector_names()[:N_DETECTORS]
+    return bifrost.default_detector_names()[:N_DETECTORS]
 
 
 @pytest.fixture(scope='module')

--- a/packages/essspectroscopy/tests/bifrost/workflow_test.py
+++ b/packages/essspectroscopy/tests/bifrost/workflow_test.py
@@ -5,7 +5,6 @@ import pytest
 import sciline
 import scipp as sc
 import scipp.testing
-import scippnexus as snx
 from ess import bifrost
 from ess.bifrost.data import (
     computed_energy_data_simulated_5x2,
@@ -28,15 +27,14 @@ from ess.spectroscopy.types import (
 
 
 @pytest.fixture(scope='module')
-def simulation_detector_names() -> list[NeXusDetectorName]:
-    with snx.File(simulated_elastic_incoherent_with_phonon()) as f:
-        names = list(f['entry']['instrument'][snx.NXdetector].keys())
-    return names[:10]  # First 10 detectors form a 5x2 grid (arc=5, channel=2)
+def detector_names() -> list[str]:
+    # First 10 detectors form a 5x2 grid (arc=5, channel=2)
+    return bifrost.detector_names()[:10]
 
 
 @pytest.fixture
-def workflow(simulation_detector_names: list[NeXusDetectorName]) -> sciline.Pipeline:
-    workflow = bifrost.BifrostSimulationWorkflow(simulation_detector_names)
+def workflow(detector_names: list[str]) -> sciline.Pipeline:
+    workflow = bifrost.BifrostSimulationWorkflow(detector_names=detector_names)
     workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()
     workflow[LookupTableFilename] = lookup_table_simulation()
     workflow[LookupTableRelativeErrorThreshold] = {
@@ -49,7 +47,7 @@ def workflow(simulation_detector_names: list[NeXusDetectorName]) -> sciline.Pipe
 
 def test_simulation_workflow_can_load_detector() -> None:
     workflow = bifrost.BifrostSimulationWorkflow(
-        [NeXusDetectorName("channel_3_1_triplet")]
+        detector_names=[NeXusDetectorName("channel_3_1_triplet")]
     )
     workflow[Filename[SampleRun]] = simulated_elastic_incoherent_with_phonon()
     results = sciline.compute_mapped(workflow, RawDetector[SampleRun])

--- a/packages/essspectroscopy/tests/bifrost/workflow_test.py
+++ b/packages/essspectroscopy/tests/bifrost/workflow_test.py
@@ -29,7 +29,7 @@ from ess.spectroscopy.types import (
 @pytest.fixture(scope='module')
 def detector_names() -> list[str]:
     # First 10 detectors form a 5x2 grid (arc=5, channel=2)
-    return bifrost.detector_names()[:10]
+    return bifrost.default_detector_names()[:10]
 
 
 @pytest.fixture


### PR DESCRIPTION
There is no need to load them from the file any more because they no longer contain an index and so are now fixed. Before, the detector names could change when components were added or removed from the files.