### PR TITLE
[CI] Do not wait for Tests to build Docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
   docs:
     name: Docs ${{ matrix.package }}
-    needs: [ changes, test ]
+    needs: [ changes, formatting ]
     if: needs.changes.outputs.packages != '[]'
     strategy:
       fail-fast: false

--- a/pixi.toml
+++ b/pixi.toml
@@ -92,7 +92,7 @@ essreduce = { path = "packages/essreduce", editable = true, extras = ["test", "d
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essreduce/.docs_doctrees packages/essreduce/docs packages/essreduce/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essreduce/.docs_doctrees packages/essreduce/docs packages/essreduce/html"
 default-environment = "docs-essreduce"
 
 [feature.docs-essimaging.pypi-dependencies]
@@ -102,7 +102,7 @@ essimaging = { path = "packages/essimaging", editable = true, extras = ["test", 
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essimaging/.docs_doctrees packages/essimaging/docs packages/essimaging/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essimaging/.docs_doctrees packages/essimaging/docs packages/essimaging/html"
 
 [feature.docs-essnmx.pypi-dependencies]
 essnmx = { path = "packages/essnmx", editable = true, extras = ["test", "docs"] }
@@ -111,7 +111,7 @@ essnmx = { path = "packages/essnmx", editable = true, extras = ["test", "docs"] 
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essnmx/.docs_doctrees packages/essnmx/docs packages/essnmx/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essnmx/.docs_doctrees packages/essnmx/docs packages/essnmx/html"
 
 [feature.docs-essreflectometry.pypi-dependencies]
 essreflectometry = { path = "packages/essreflectometry", editable = true, extras = ["test", "docs"] }
@@ -120,7 +120,7 @@ essreflectometry = { path = "packages/essreflectometry", editable = true, extras
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essreflectometry/.docs_doctrees packages/essreflectometry/docs packages/essreflectometry/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essreflectometry/.docs_doctrees packages/essreflectometry/docs packages/essreflectometry/html"
 
 [feature.docs-essdiffraction.pypi-dependencies]
 essdiffraction = { path = "packages/essdiffraction", editable = true, extras = ["test", "docs"] }
@@ -129,7 +129,7 @@ essdiffraction = { path = "packages/essdiffraction", editable = true, extras = [
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essdiffraction/.docs_doctrees packages/essdiffraction/docs packages/essdiffraction/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essdiffraction/.docs_doctrees packages/essdiffraction/docs packages/essdiffraction/html"
 
 [feature.docs-esssans.pypi-dependencies]
 esssans = { path = "packages/esssans", editable = true, extras = ["test", "docs"] }
@@ -138,7 +138,7 @@ esssans = { path = "packages/esssans", editable = true, extras = ["test", "docs"
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/esssans/.docs_doctrees packages/esssans/docs packages/esssans/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/esssans/.docs_doctrees packages/esssans/docs packages/esssans/html"
 
 [feature.docs-essspectroscopy.pypi-dependencies]
 essspectroscopy = { path = "packages/essspectroscopy", editable = true, extras = ["test", "docs"] }
@@ -147,7 +147,7 @@ essspectroscopy = { path = "packages/essspectroscopy", editable = true, extras =
 args = [
     { "arg" = "builder", "default" = "html" },
 ]
-cmd = "python -m sphinx -v -b {{ builder }} -d packages/essspectroscopy/.docs_doctrees packages/essspectroscopy/docs packages/essspectroscopy/html"
+cmd = "python -m sphinx -v -b {{ builder }}{% if builder in ['linkcheck', 'doctest'] %} -D nbsphinx_execute=never{% endif %} -d packages/essspectroscopy/.docs_doctrees packages/essspectroscopy/docs packages/essspectroscopy/html"
 
 # ==================== Environments ====================
 


### PR DESCRIPTION
Resoning:

Failing early is useful, but these days the unit tests seem to be almost as slow as building the docs.

It is sometimes useful to see that both tests and docs builds are broken, so we can fix everything at once.

Also, if the author of the PR has done things properly and tested both tests and docs locally, it shouldn't really fail.

It does seem a bit strange to have to wait for the long unit tests to all complete while we could spend some of that waiting time starting to build docs, since we have quite a few runners for the organisation? (this is especially true when pushing changes to `essreduce`).

Total runtime for running everything decreased from 22m to ~14m~ :slightly_smiling_face: 

Edit: got it down to 10m30s by not executing the notebooks during doctest and linkcheck