### PR TITLE
[ESSREDUCE] Seed RNG in cylindrical pixel position noise

### DIFF
--- a/packages/essreduce/src/ess/reduce/live/raw.py
+++ b/packages/essreduce/src/ess/reduce/live/raw.py
@@ -739,7 +739,7 @@ def position_noise_for_cylindrical_pixel(
     # fulfill this. However, the rest of the data reduction currently assumes that
     # the pixel offset corresponds to the pixel center, so if it is not fulfilled
     # there are bigger problems elsewhere anywhere.
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=1234)
     dims = ('position',)
     size = _noise_size
     z_hat = axis / sc.norm(axis)  # Unit vector along the cylinder axis

--- a/packages/essreduce/tests/live/raw_test.py
+++ b/packages/essreduce/tests/live/raw_test.py
@@ -19,6 +19,14 @@ def test_gaussian_position_noise_is_sigma_unit_independent(sigma: sc.Variable) -
     assert sc.identical(noise, reference)
 
 
+def test_position_noise_for_cylindrical_pixel_is_deterministic() -> None:
+    axis = raw.PixelCylinderAxis(sc.vector([0.0, 0.0, 1.0], unit='m'))
+    radius = raw.PixelCylinderRadius(sc.vector([0.5, 0.0, 0.0], unit='m'))
+    reference = raw.position_noise_for_cylindrical_pixel(axis=axis, radius=radius)
+    noise = raw.position_noise_for_cylindrical_pixel(axis=axis, radius=radius)
+    assert sc.identical(noise, reference)
+
+
 def test_clear_counts_resets_counts_to_zero() -> None:
     detector_number = sc.array(dims=['pixel'], values=[1, 2, 3], unit=None)
     det = raw.Detector(detector_number)


### PR DESCRIPTION
`position_noise_for_cylindrical_pixel` created its RNG with an unseeded `np.random.default_rng()`, whereas its sibling `gaussian_position_noise` uses a fixed seed. This made the cylindrical pixel noise — and therefore all downstream projected coordinates — change on every call, which is undesirable for reproducible reductions and comparisons. Seeding the generator with the same value as the gaussian variant makes the output deterministic.

The added test asserts that two successive calls produce identical noise; it fails on the previous code and passes with the fix.
