### PR TITLE
[CI] Add release note generating step in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ on:
   push:
     tags:
       - "*/[0-9]*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag - hardcoded.'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run the release action.'
+        default: false
+        type: boolean
 
 env:
   PIXI_FROZEN: true
@@ -19,7 +29,11 @@ jobs:
     steps:
       - id: parse
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          if [ ${{ inputs.dry-run }} = true ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          else
+            TAG=${{ inputs.tag }}
+          fi
           PACKAGE="${TAG%%/*}"
           VERSION="${TAG#*/}"
           echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
@@ -50,6 +64,7 @@ jobs:
     needs: [ determine-package, build ]
     runs-on: ubuntu-24.04
     environment: release
+    if: ${{ !inputs.dry-run }}
     permissions:
       id-token: write
     steps:
@@ -69,7 +84,7 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       package: ${{ needs.determine-package.outputs.package }}
-      publish: true
+      publish: ${{ !inputs.dry-run }}
       linkcheck: false
 
   assets:
@@ -91,6 +106,7 @@ jobs:
           zip -r documentation-${PACKAGE}-${VERSION}.zip documentation-${PACKAGE}-${VERSION}
       - name: Upload release assets
         uses: svenstaro/upload-release-action@v2
+        if: ${{ !inputs.dry-run }}
         with:
           file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
           overwrite: false
@@ -134,10 +150,10 @@ jobs:
       LAST_VERSION: ${{ needs.determine-last-release.outputs.lastversion }}
     steps:
       - name: Download PR metadata cache
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
-          key: ess_release_cache-${PACKAGE}-${VERSION}
-          restore-keys: ess_release_cache
+          key: ess-release-cache-${PACKAGE}-${VERSION}
+          restore-keys: ess-release-cache
           path: .ess_release_cache
       - uses: actions/checkout@v6
         with:
@@ -155,14 +171,19 @@ jobs:
         run: ls .ess_release_cache
       - name: Generate release note
         run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LAST_VERSION}
-      - name: Merge existing release note with generated note
-        run: |
-          gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body >> existing-note.md
+      - name: Download existing release note
+        run: |  # If release does not exist yet, `existing-note.md` will be empty.
+          gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body > existing-note.md
           if [ -s existing-note.md ]; then
             cat existing-note.md >> new-release-note.md
           fi
-          cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md >> new-release-note.md
+      - name: Merge existing release note with generated note
+        run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md >> new-release-note.md
+      - name: Check the generated note
+        if: ${{ inputs.dry-run }}
+        run: cat new-release-note.md
       - name: Upload release note
+        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,14 @@ jobs:
         run: ls .ess_release_cache
       - name: Generate release note
         run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LAST_VERSION}
+      - name: Merge existing release note with generated note
+        run: |
+          gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body >> existing-note.md
+          if [ -s existing-note.md ]; then
+            cat existing-note.md >> new-release-note.md
+          fi
+          cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md >> new-release-note.md
       - name: Upload release note
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit ${PACKAGE}/${VERSION} --notes-file ".ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md"
+        run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,68 @@ jobs:
         with:
           file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
           overwrite: false
+
+  determine-last-release:
+    name: Determine last release of the package
+    needs: [ determine-package ]
+    runs-on: ubuntu-slim
+    env:
+      PACKAGE: ${{ needs.determine-package.outputs.package }}
+      VERSION: ${{ needs.determine-package.outputs.version }}
+    outputs:
+      lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - id: last-version-parse
+        run: |
+          previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
+          echo "Previous releases: ${previous_releases[@]}"
+          if [[ ${#previous_releases[@]} -gt 1 ]]; then
+          	LAST_RELEASE=${previous_releases[-2]}
+            if [[ "${LAST_RELEASE}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              echo "lastversion=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+              echo "Found last release version: ${BASH_REMATCH[2]}"
+            fi
+          else
+          	echo "No previous release found for the package."
+          fi
+
+  notes:
+    name: Update notes
+    needs: [ determine-package, publish, determine-last-release ]
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    env:
+      PACKAGE: ${{ needs.determine-package.outputs.package }}
+      VERSION: ${{ needs.determine-package.outputs.version }}
+      LAST_VERSION: ${{ needs.determine-last-release.outputs.lastversion }}
+    steps:
+      - name: Download PR metadata cache
+        uses: actions/cache@v5
+        with:
+          key: ess_release_cache-${PACKAGE}-${VERSION}
+          restore-keys: ess_release_cache
+          path: .ess_release_cache
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install dependencise
+        run: pip install pydantic==2.13.3
+      - name: Download PR metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LAST_VERSION}
+      - name: Check downloaded cache
+        run: ls .ess_release_cache
+      - name: Generate release note
+        run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LAST_VERSION}
+      - name: Upload release note
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit ${PACKAGE}/${VERSION} --notes-file ".ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md"

--- a/tools/collect-release-notes.py
+++ b/tools/collect-release-notes.py
@@ -62,6 +62,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--cur-tag", help="Current Tag for Release")
     parser.add_argument("--compare-tag", help="Last Tag for Comparison")
+    parser.add_argument(
+        "--maybe-relevant", help="Keep irrelevant PRs in the note.", action='store_true'
+    )
     parser.add_argument("--output-file-path", help="Path to save the output.")
 
     args = parser.parse_args()
@@ -70,15 +73,16 @@ if __name__ == "__main__":
     package_name = cur_tag.split('/')[0]
     commit_list_file = get_commits_file(cur_tag, compare_tag)
 
+    commit_cache_dir = CACHE_DIR / "commits"
     commits = commit_list_file.read_text().splitlines()
     merge_logs = []
     for commit in commits:
-        pr_json = CACHE_DIR / commit / "all-prs.json"
+        pr_json = commit_cache_dir / commit / "all-prs.json"
         pr_list = json.loads(pr_json.read_text())
         for pr in pr_list:
             pr_obj = PRDescription(**pr)
             pr_commits_list_json = (
-                CACHE_DIR / commit / f"pr-{pr_obj.number}-commits.json"
+                commit_cache_dir / commit / f"pr-{pr_obj.number}-commits.json"
             )
             pr_commits_list = json.loads(pr_commits_list_json.read_text())
             authors = set()
@@ -103,8 +107,12 @@ if __name__ == "__main__":
     ]
     release_note.extend([f"* {relevant_log}" for relevant_log in relevant_logs])
 
-    release_note.extend(['', '### Maybe Related Changes', ''])
-    release_note.extend([f"* {relevant_log}" for relevant_log in maybe_relevant_logs])
+    if args.maybe_relevant:
+        release_note.extend(['', '### Maybe Related Changes', ''])
+        release_note.extend(
+            [f"* {relevant_log}" for relevant_log in maybe_relevant_logs]
+        )
+
     release_note.extend(
         [
             '',

--- a/tools/collect-release-notes.py
+++ b/tools/collect-release-notes.py
@@ -60,12 +60,20 @@ def has_label(label: str, pr: PRDescription) -> bool:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cur-tag", help="Current Tag for Release")
-    parser.add_argument("--compare-tag", help="Last Tag for Comparison")
+    parser.add_argument("--cur-tag", help="Current Tag for Release", required=True)
+    parser.add_argument("--compare-tag", help="Last Tag for Comparison", required=True)
     parser.add_argument(
-        "--maybe-relevant", help="Keep irrelevant PRs in the note.", action='store_true'
+        "--maybe-relevant",
+        help="Keep irrelevant PRs in the note.",
+        action='store_true',
+        default=False,
     )
-    parser.add_argument("--output-file-path", help="Path to save the output.")
+    parser.add_argument(
+        "--output-file-path",
+        help="Path to save the output.",
+        required=False,
+        default=None,
+    )
 
     args = parser.parse_args()
     cur_tag = args.cur_tag

--- a/tools/download-release-diff-info.sh
+++ b/tools/download-release-diff-info.sh
@@ -42,7 +42,7 @@ else
 fi
 echo "Found the last previous release on the package ${PACKAGE}: ${LAST_RELEASE}"
 
-commits_between=($(git log --pretty=format:%H ${LAST_RELEASE}...${CUR_TAG}));
+commits_between=($(git log --first-parent --pretty=format:%H ${LAST_RELEASE}...${CUR_TAG}));
 echo "${#commits_between[@]} commits found in between.";
 
 download_commit_and_pr_info() {

--- a/tools/download-release-diff-info.sh
+++ b/tools/download-release-diff-info.sh
@@ -1,10 +1,12 @@
 #!bin/bash
-
-CUR_TAG=$(git describe --tags --abbrev=0)
+if [[ -z $1 ]]; then
+  CUR_TAG=$(git describe --tags --abbrev=0);
+else
+  CUR_TAG=$1;
+fi
 # Prepare Cache Folder
 GIT_TOP_DIR=$(git rev-parse --show-toplevel)
 CACHE_DIR=${GIT_TOP_DIR}/.ess_release_cache
-
 
 echo "Current tag: ${CUR_TAG}"
 
@@ -12,42 +14,54 @@ PACKAGE=""
 VERSION=""
 
 if [[ "${CUR_TAG}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-	PACKAGE=${BASH_REMATCH[1]}
-	VERSION=${BASH_REMATCH[2]}
+	PACKAGE=${BASH_REMATCH[1]};
+	VERSION=${BASH_REMATCH[2]};
 else
-	echo "Tag name unexpected..."
-	exit 1
+	echo "Tag name unexpected...";
+	exit 1;
 fi
 
-echo "Package: ${PACKAGE}"
-echo "Version: ${VERSION}"
+echo "Package: ${PACKAGE}";
+echo "Version: ${VERSION}";
 
 find_last_release() {
-	previous_releases=($(git tag -l ${PACKAGE}* --sort creatordate))
-	echo $previous_releases
+	previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
+	echo "Previous releases: ${previous_releases[@]}";
 	if [[ ${#previous_releases[@]} -gt 1 ]]; then
-		LAST_RELEASE=${previous_releases[-2]}
+		LAST_RELEASE=${previous_releases[-2]};
 	else
-		echo "No previous release found on the package yet. Can't collect release notes automatically..."
-		exit 1
+		echo "No previous release found on the package yet. Can't collect release notes automatically...";
+		exit 1;
 	fi
 }
 
-find_last_release
-echo "Found the previous release on the package ${PACKAGE}: ${LAST_RELEASE}"
+if [[ -z $2 ]]; then
+  find_last_release
+else
+  LAST_RELEASE=$2;
+fi
+echo "Found the last previous release on the package ${PACKAGE}: ${LAST_RELEASE}"
 
-commits_between=($(git log --first-parent --merges --pretty=format:%H ${LAST_RELEASE}...${CUR_TAG}))
+commits_between=($(git log --pretty=format:%H ${LAST_RELEASE}...${CUR_TAG}));
+echo "${#commits_between[@]} commits found in between.";
 
 download_commit_and_pr_info() {
 	local RELEASE_COMMITS_LIST=${CACHE_DIR}/${CUR_TAG/\//-}-${LAST_RELEASE/\//-}-commits.txt
-	rm ${RELEASE_COMMITS_LIST};
+	if [ -f ${RELEASE_COMMITS_LIST} ]; then
+	  echo "${RELEASE_COMMITS_LIST} already exists. Cleaning up first...";
+	  rm ${RELEASE_COMMITS_LIST};
+	fi
+	# Make an empty commit list file in case there is no commits at all.
+	mkdir -p ${CACHE_DIR};
+	touch ${RELEASE_COMMITS_LIST};
+
 	for commit in ${commits_between[@]}; do
 		echo ${commit} >>${RELEASE_COMMITS_LIST}
-		commit_dir=${CACHE_DIR}/${commit}
+		commit_dir=${CACHE_DIR}/commits/${commit}
 		if [ -d ${commit_dir} ]; then
 			echo "commit cache directory already exists with these files: $(ls ${commit_dir})"
 		else
-			mkdir --parent ${commit_dir}
+			mkdir -p ${commit_dir}
 		fi
 
 		pr_json=${commit_dir}/all-prs.json


### PR DESCRIPTION
Release note editting steps are added in the `release.yml`.

It's split into two jobs:
- download all the relevant commits/pr information using github API (bash script)
- generate the release note from the downloaded information (python script)

I tested in a fork https://github.com/YooSunYoung/ess/releases/tag/essnmx%2F26.6.2
but not sure if it would work as expected in the action here as well...

# Manual Test
Here is the example how I ran the scripts using `essnmx/26.6.0` and `essnmx/26.4.0` as an example.

## Prerequisites
```
git fetch --tags  # Or only relevant tags...
```
## Download the commit information
The script only runs with `bash` since it has some syntax that `sh` doesn't have...
```
bash tools/download-release-diff-info.sh essnmx/26.6.0 essnmx/26.4.0
```
## Generate release note.
```
pixi run --frozen python tools/collect-release-notes.py --cur-tag essnmx/26.6.0 --compare-tag essnmx/26.4.0
```

By default, the generated note will be stored under `.ess_release_cache/`, <br>
so in this case, `.ess_release_cache/essnmx-26.6.0-essnmx-26.4.0-releasenote.md`.

Here is the example output from this test:

## What's Changed

### ESSnmx

* Bump essreduce to 26.6.0 by @jl-wynen in https://api.github.com/repos/scipp/ess/pulls/624
* [ESSNMX] Save TOF 1d histogram by @YooSunYoung in https://api.github.com/repos/scipp/ess/pulls/600
* ci: add lower bound and latest released nightlies by @jokasimr in https://api.github.com/repos/scipp/ess/pulls/606
* [NMX] Reference data comparison test. by @YooSunYoung in https://api.github.com/repos/scipp/ess/pulls/546
* [NMX] Allow setting output time bin unit. by @YooSunYoung in https://api.github.com/repos/scipp/ess/pulls/545
* [Essnmx] Use time bin width instead of number of bin edges. by @YooSunYoung in https://api.github.com/repos/scipp/ess/pulls/264


**Full Changelog**: https://github.com/scipp/ess/compare/essnmx/26.4.0...essnmx/26.6.0

