### PR TITLE
[CI] Fix release action note generator.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
   determine-package:
     name: Determine package and version, last-version.
     runs-on: ubuntu-slim
-    env:
-      DRYRUN: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
       lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
+    env:
+      DRYRUN: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - id: parse
         name: Parse package and version name.
@@ -86,7 +86,7 @@ jobs:
     needs: [ determine-package, build ]
     runs-on: ubuntu-24.04
     environment: release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'workflow_dispatch' }}
     permissions:
       id-token: write
     steps:
@@ -106,7 +106,7 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       package: ${{ needs.determine-package.outputs.package }}
-      publish: ${{ github.event_name != 'workflow_dispatch' }}
+      publish: true
       linkcheck: false
 
   assets:
@@ -128,7 +128,6 @@ jobs:
           zip -r documentation-${PACKAGE}-${VERSION}.zip documentation-${PACKAGE}-${VERSION}
       - name: Upload release assets
         uses: svenstaro/upload-release-action@v2
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
           overwrite: false
@@ -179,7 +178,6 @@ jobs:
       - name: Merge existing release note with generated note
         run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LASTVERSION}-releasenote.md >> new-release-note.md
       - name: Check the generated note
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: cat new-release-note.md
       - name: Upload release note
         if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
       - id: parse
         run: |
           if [ ${{ inputs.dry-run }} = true ]; then
-            TAG="${GITHUB_REF#refs/tags/}"
-          else
             TAG=${{ inputs.tag }}
+          else            
+            TAG="${GITHUB_REF#refs/tags/}"
           fi
           PACKAGE="${TAG%%/*}"
           VERSION="${TAG#*/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,8 @@ jobs:
       - name: Generate release note
         run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LASTVERSION}
       - name: Download existing release note
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |  # If release does not exist yet, `existing-note.md` will be empty.
           gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body > existing-note.md
           if [ -s existing-note.md ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
           echo "Previous releases: ${previous_releases[@]}"
           if [[ ${#previous_releases[@]} -gt 1 ]]; then
-          	LAST_RELEASE=${previous_releases[-2]}
+          	LAST_RELEASE=${previous_releases[-1]}
             if [[ "${LAST_RELEASE}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               echo "lastversion=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
               echo "Found last release version: ${BASH_REMATCH[2]}"
@@ -142,6 +142,7 @@ jobs:
     name: Update notes
     needs: [ determine-package, publish, determine-last-release ]
     runs-on: ubuntu-slim
+    if: always()
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ env:
 
 jobs:
   determine-package:
-    name: Determine package
-    runs-on: ubuntu-24.04
+    name: Determine package and version, last-version.
+    runs-on: ubuntu-slim
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
+      lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
     steps:
       - id: parse
         run: |
@@ -38,6 +39,22 @@ jobs:
           VERSION="${TAG#*/}"
           echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v6
+        with:
+          fetch-tags: true
+      - id: last-version-parse
+        run: |
+          previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
+          echo "Previous releases: ${previous_releases[@]}"
+          if [[ ${#previous_releases[@]} -gt 1 ]]; then
+          	LAST_RELEASE=${previous_releases[-1]}
+            if [[ "${LAST_RELEASE}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              echo "lastversion=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+              echo "Found last release version: ${BASH_REMATCH[2]}"
+            fi
+          else
+          	echo "No previous release found for the package."
+          fi
 
   build:
     name: Build ${{ needs.determine-package.outputs.package }}
@@ -111,36 +128,9 @@ jobs:
           file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
           overwrite: false
 
-  determine-last-release:
-    name: Determine last release of the package
-    needs: [ determine-package ]
-    runs-on: ubuntu-slim
-    env:
-      PACKAGE: ${{ needs.determine-package.outputs.package }}
-      VERSION: ${{ needs.determine-package.outputs.version }}
-    outputs:
-      lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-tags: true
-      - id: last-version-parse
-        run: |
-          previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
-          echo "Previous releases: ${previous_releases[@]}"
-          if [[ ${#previous_releases[@]} -gt 1 ]]; then
-          	LAST_RELEASE=${previous_releases[-1]}
-            if [[ "${LAST_RELEASE}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-              echo "lastversion=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
-              echo "Found last release version: ${BASH_REMATCH[2]}"
-            fi
-          else
-          	echo "No previous release found for the package."
-          fi
-
   notes:
     name: Update notes
-    needs: [ determine-package, publish, determine-last-release ]
+    needs: [ determine-package, publish ]
     runs-on: ubuntu-slim
     if: always()
     permissions:
@@ -148,7 +138,7 @@ jobs:
     env:
       PACKAGE: ${{ needs.determine-package.outputs.package }}
       VERSION: ${{ needs.determine-package.outputs.version }}
-      LAST_VERSION: ${{ needs.determine-last-release.outputs.lastversion }}
+      LASTVERSION: ${{ needs.determine-package.outputs.lastversion }}
     steps:
       - name: Download PR metadata cache
         uses: actions/cache@v5.0.5
@@ -167,11 +157,11 @@ jobs:
       - name: Download PR metadata
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LAST_VERSION}
+        run: bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LASTVERSION}
       - name: Check downloaded cache
         run: ls .ess_release_cache
       - name: Generate release note
-        run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LAST_VERSION}
+        run: python tools/collect-release-notes.py --cur-tag ${PACKAGE}/${VERSION} --compare-tag ${PACKAGE}/${LASTVERSION}
       - name: Download existing release note
         run: |  # If release does not exist yet, `existing-note.md` will be empty.
           gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body > existing-note.md
@@ -179,7 +169,7 @@ jobs:
             cat existing-note.md >> new-release-note.md
           fi
       - name: Merge existing release note with generated note
-        run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LAST_VERSION}-releasenote.md >> new-release-note.md
+        run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LASTVERSION}-releasenote.md >> new-release-note.md
       - name: Check the generated note
         if: ${{ inputs.dry-run }}
         run: cat new-release-note.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
     # Trigger the action with workflow_dispatch.
     # Any steps or jobs that make side-effect should be skipped on the workflow_dispatch.
+    # Note generating steps only work if the hardcoded tag is the latest version of the package.
     inputs:
       tag:
         description: 'Release tag - hardcoded for dry-run test.'
@@ -52,7 +53,7 @@ jobs:
           previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
           echo "Previous releases: ${previous_releases[@]}"
           if [[ ${#previous_releases[@]} -gt 1 ]]; then
-          	LAST_RELEASE=${previous_releases[-1]}
+          	LAST_RELEASE=${previous_releases[-2]}
             if [[ "${LAST_RELEASE}" =~ ^(^ess[^@]+)\/([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               echo "lastversion=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
               echo "Found last release version: ${BASH_REMATCH[2]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           path: .ess_release_cache
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # Fetch depth must be 0 otherwise the git log comment won't find all relevant commits between tags.
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: "3.11"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
       lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
     steps:
       - id: parse
+        name: Parse package and version name.
         run: |
           if [ ${DRYRUN} = true ]; then
             TAG=${{ inputs.tag }}
@@ -42,7 +43,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - id: last-version-parse          
+      - id: last-version-parse
+        name: Parse the previous version if possible.
+        continue-on-error: true  # Previous version may not exist.
         run: |
           PACKAGE=${{ steps.parse.outputs.package }}
           VERSION=${{ steps.parse.outputs.package }}
@@ -134,7 +137,7 @@ jobs:
     name: Update notes
     needs: [ determine-package, publish ]
     runs-on: ubuntu-slim
-    if: always()
+    if: ${{ always() && needs.determine-package.outputs.lastversion }}
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag - hardcoded.'
+        description: 'Release tag - hardcoded for dry-run test.'
         required: true
         type: string
-      dry-run:
-        description: 'Dry run the release action.'
-        default: false
-        type: boolean
 
 env:
   PIXI_FROZEN: true
@@ -23,6 +19,8 @@ jobs:
   determine-package:
     name: Determine package and version, last-version.
     runs-on: ubuntu-slim
+    env:
+      DRYRUN: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
@@ -30,9 +28,9 @@ jobs:
     steps:
       - id: parse
         run: |
-          if [ ${{ inputs.dry-run }} = true ]; then
+          if [ ${DRYRUN} = true ]; then
             TAG=${{ inputs.tag }}
-          else            
+          else
             TAG="${GITHUB_REF#refs/tags/}"
           fi
           PACKAGE="${TAG%%/*}"
@@ -81,7 +79,7 @@ jobs:
     needs: [ determine-package, build ]
     runs-on: ubuntu-24.04
     environment: release
-    if: ${{ !inputs.dry-run }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     permissions:
       id-token: write
     steps:
@@ -101,7 +99,7 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       package: ${{ needs.determine-package.outputs.package }}
-      publish: ${{ !inputs.dry-run }}
+      publish: ${{ github.event_name != 'workflow_dispatch' }}
       linkcheck: false
 
   assets:
@@ -123,7 +121,7 @@ jobs:
           zip -r documentation-${PACKAGE}-${VERSION}.zip documentation-${PACKAGE}-${VERSION}
       - name: Upload release assets
         uses: svenstaro/upload-release-action@v2
-        if: ${{ !inputs.dry-run }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
           overwrite: false
@@ -173,10 +171,10 @@ jobs:
       - name: Merge existing release note with generated note
         run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LASTVERSION}-releasenote.md >> new-release-note.md
       - name: Check the generated note
-        if: ${{ inputs.dry-run }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: cat new-release-note.md
       - name: Upload release note
-        if: ${{ !inputs.dry-run }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "*/[0-9]*"
   workflow_dispatch:
+    # Trigger the action with workflow_dispatch.
+    # Any steps or jobs that make side-effect should be skipped on the workflow_dispatch.
     inputs:
       tag:
         description: 'Release tag - hardcoded for dry-run test.'
@@ -174,7 +176,7 @@ jobs:
       - name: Merge existing release note with generated note
         run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LASTVERSION}-releasenote.md >> new-release-note.md
       - name: Check the generated note
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: cat new-release-note.md
       - name: Upload release note
         if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-tags: true
-      - id: last-version-parse
+      - id: last-version-parse          
         run: |
+          PACKAGE=${{ steps.parse.outputs.package }}
+          VERSION=${{ steps.parse.outputs.package }}
           previous_releases=($(git tag -l ${PACKAGE}/* --sort creatordate))
           echo "Previous releases: ${previous_releases[@]}"
           if [[ ${#previous_releases[@]} -gt 1 ]]; then
@@ -163,6 +165,7 @@ jobs:
       - name: Download existing release note
         env:
           GH_TOKEN: ${{ github.token }}
+        continue-on-error: true  # Release note might not exist yet.
         run: |  # If release does not exist yet, `existing-note.md` will be empty.
           gh release view ${PACKAGE}/${VERSION} -R scipp/ess --json body -q .body > existing-note.md
           if [ -s existing-note.md ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           path: .ess_release_cache
       - uses: actions/checkout@v6
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: "3.11"
@@ -162,9 +162,7 @@ jobs:
       - name: Download PR metadata
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          git log --first-parent --pretty=format:%H ${PACKAGE}/${LASTVERSION}...${PACKAGE}/${VERSION}
-          bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LASTVERSION}
+        run: bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LASTVERSION}
       - name: Check downloaded cache
         run: ls .ess_release_cache
       - name: Generate release note

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,9 @@ jobs:
       - name: Download PR metadata
         env:
           GH_TOKEN: ${{ github.token }}
-        run: bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LASTVERSION}
+        run: |
+          git log --first-parent --pretty=format:%H ${PACKAGE}/${LASTVERSION}...${PACKAGE}/${VERSION}
+          bash tools/download-release-diff-info.sh ${PACKAGE}/${VERSION} ${PACKAGE}/${LASTVERSION}
       - name: Check downloaded cache
         run: ls .ess_release_cache
       - name: Generate release note


### PR DESCRIPTION
After some try/failure loops, I fixed all the errors of note-generating job and workflow-dispatch.

Here is the last successful action log with workflow-dispatch:
https://github.com/scipp/ess/actions/runs/27621421658/job/81671268522

With the workflow-dispatch, it runs the build job and the release-note generating job.
I wasn't sure if we want to run the docs build as well since it already has a workflow-dispatch trigger.

Intended way of using the trigger is to set `tag` manually using the workflow-dispatch UI in the github action page of this repo, setting the tag with the existing latest tag of any packages.

For example, in the test I used `essnmx/26.6.0` as the hard coded tag, since it is the last release of `essnmx` at the moment.