### PR TITLE
[CI] Add draft release step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
+      tag: ${{ steps.parse.outputs.tag }}
       lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
     env:
       DRYRUN: ${{ github.event_name == 'workflow_dispatch' }}
@@ -39,6 +40,7 @@ jobs:
           fi
           PACKAGE="${TAG%%/*}"
           VERSION="${TAG#*/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
@@ -99,6 +101,19 @@ jobs:
         with:
           packages-dir: dist/
 
+  draft-release:
+    name: Publish release
+    needs: [ publish, determine-package ]
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+    steps:
+      - name: Draft a release.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.determine-package.outputs.tag }}
+        run: gh release create ${TAG} --draft --title ${TAG}  # Default title is not always the tag name.
+
   docs:
     name: Build and publish docs
     needs: [ determine-package, publish ]
@@ -112,7 +127,7 @@ jobs:
 
   assets:
     name: Upload docs
-    needs: [ docs, determine-package ]
+    needs: [ docs, determine-package, draft-release ]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -128,14 +143,15 @@ jobs:
           mv docs_html documentation-${PACKAGE}-${VERSION}
           zip -r documentation-${PACKAGE}-${VERSION}.zip documentation-${PACKAGE}-${VERSION}
       - name: Upload release assets
-        uses: svenstaro/upload-release-action@v2
-        with:
-          file: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
-          overwrite: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ASSET-FILE-PATH: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
+          TAG: ${{ needs.determine-package.outputs.tag }}
+        run: gh release upload ${TAG} ${ASSET-FILE-PATH} --clobber  # Overwrite existing assets of the same name.
 
   notes:
     name: Update notes
-    needs: [ determine-package, publish ]
+    needs: [ determine-package, publish, draft-release ]
     runs-on: ubuntu-slim
     if: ${{ always() && needs.determine-package.outputs.lastversion }}
     permissions:
@@ -180,8 +196,8 @@ jobs:
         run: cat .ess_release_cache/${PACKAGE}-${VERSION}-${PACKAGE}-${LASTVERSION}-releasenote.md >> new-release-note.md
       - name: Check the generated note
         run: cat new-release-note.md
-      - name: Upload release note
+      - name: Upload release note and publish the release
         if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md"
+        run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md" --draft=false  # Publish the release with the new note.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [ determine-package, build ]
+    needs: build
     runs-on: ubuntu-24.04
     environment: release
     if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,17 +100,21 @@ jobs:
           packages-dir: dist/
 
   draft-release:
-    name: Draft a release
+    name: Draft a release or/and check the release
     needs: [ determine-package, publish ]
     runs-on: ubuntu-slim
     permissions:
       contents: write
+    env:
+      TAG: ${{ needs.determine-package.outputs.package }}/${{ needs.determine-package.outputs.version }}
     steps:
       - name: Draft a release.
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.determine-package.outputs.package }}/${{ needs.determine-package.outputs.version }}
         run: gh release create ${TAG} --draft --title ${TAG}  # Default title is not always the tag name.
+        continue-on-error: true  # Release create can fail if there is an existing release.
+      - name: Check the release.
+        run: gh release view ${TAG}  # This command should not fail.
 
   docs:
     name: Build and publish docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
           packages-dir: dist/
 
   draft-release:
-    name: Publish release
+    name: Draft a release
     needs: [ determine-package, publish ]
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     outputs:
       package: ${{ steps.parse.outputs.package }}
       version: ${{ steps.parse.outputs.version }}
-      tag: ${{ steps.parse.outputs.tag }}
       lastversion: ${{ steps.last-version-parse.outputs.lastversion }}
     env:
       DRYRUN: ${{ github.event_name == 'workflow_dispatch' }}
@@ -103,7 +102,7 @@ jobs:
 
   draft-release:
     name: Publish release
-    needs: [ publish, determine-package ]
+    needs: [ determine-package, publish ]
     runs-on: ubuntu-slim
     permissions:
       contents: write
@@ -111,7 +110,7 @@ jobs:
       - name: Draft a release.
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.determine-package.outputs.tag }}
+          TAG: ${{ needs.determine-package.outputs.package }}/${{ needs.determine-package.outputs.version }}
         run: gh release create ${TAG} --draft --title ${TAG}  # Default title is not always the tag name.
 
   docs:
@@ -146,12 +145,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ASSET-FILE-PATH: ./documentation-${{ needs.determine-package.outputs.package }}-${{ needs.determine-package.outputs.version }}.zip
-          TAG: ${{ needs.determine-package.outputs.tag }}
+          TAG: ${{ needs.determine-package.outputs.package }}/${{ needs.determine-package.outputs.version }}
         run: gh release upload ${TAG} ${ASSET-FILE-PATH} --clobber  # Overwrite existing assets of the same name.
 
   notes:
     name: Update notes
-    needs: [ determine-package, publish, draft-release ]
+    needs: [ determine-package, draft-release ]
     runs-on: ubuntu-slim
     if: ${{ always() && needs.determine-package.outputs.lastversion }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         run: gh release create ${TAG} --draft --title ${TAG}  # Default title is not always the tag name.
         continue-on-error: true  # Release create can fail if there is an existing release.
       - name: Check the release.
-        run: gh release view ${TAG}  # This command should not fail.
+        run: gh release view ${TAG}  # This command should not fail if the release already exists or was created by the previous step.
 
   docs:
     name: Build and publish docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ jobs:
           fi
           PACKAGE="${TAG%%/*}"
           VERSION="${TAG#*/}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "package=${PACKAGE}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6

--- a/tools/collect-release-notes.py
+++ b/tools/collect-release-notes.py
@@ -39,7 +39,7 @@ class MergeLog(BaseModel):
 
     def __str__(self) -> str:
         authors = ", ".join([f"@{author.login}" for author in self.authors])
-        return f"{self.pr.title} by {authors} in {self.pr.url}"
+        return f"{self.pr.title} by {authors} in #{self.pr.number}"
 
 
 def get_commits_file(cur_tag: str, compare_tag: str) -> pathlib.Path:

--- a/tools/collect-release-notes.py
+++ b/tools/collect-release-notes.py
@@ -39,7 +39,7 @@ class MergeLog(BaseModel):
 
     def __str__(self) -> str:
         authors = ", ".join([f"@{author.login}" for author in self.authors])
-        return f"{self.pr.title} by {authors} in #{self.pr.number}"
+        return f"{self.pr.title} by {authors} in https://github.com/scipp/ess/pull/{self.pr.number}"
 
 
 def get_commits_file(cur_tag: str, compare_tag: str) -> pathlib.Path:

--- a/tools/collect-release-notes.py
+++ b/tools/collect-release-notes.py
@@ -107,12 +107,7 @@ if __name__ == "__main__":
         else:
             maybe_relevant_logs.append(merge_log)
 
-    release_note = [
-        "## What's Changed",
-        '',
-        f"### {package_name.replace('ess', 'ESS')}",
-        '',
-    ]
+    release_note = ["## What's Changed"]
     release_note.extend([f"* {relevant_log}" for relevant_log in relevant_logs])
 
     if args.maybe_relevant:


### PR DESCRIPTION
The release note upload job failed because the release was not drafted/published yet.
It was depending on the assets uploading job to create the release if not present.

It used default values for creating the release if there is None for the given tag.
Then the title was set to a weird commit message instead of the tag name (it depends on how many commits belong to the PR apparently?).

So I added an explicit release draft step with the specific title(tag name).
In this way we can use the runners a bit more efficiently... (release note generating and docs build can take a while.)

Also I removed the upload file action and used `gh` cli directly instead.

The release note uploading job is responsible for publishing the release,
i.e. the release is set to latest/published from draft when there is a release note.

Assets uploading (built docs) won't be necessarily done by the time the release is published.