### PR TITLE
[CI] Fix upload for imaging nightly reduced data

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,8 @@ jobs:
             file_output: true
           - package: essreflectometry
             file_output: true
+          - package: essimaging
+            file_output: true
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
After addition of the test that publishes images in #641 , we forgot to also update the nightly workflow.