### PR TITLE
[ESSREDUCE] Avoid thread-unsafe warning suppression in unwrap _polygon_intersections

### DIFF
--- a/packages/essreduce/src/ess/reduce/unwrap/lut.py
+++ b/packages/essreduce/src/ess/reduce/unwrap/lut.py
@@ -4,7 +4,6 @@
 Utilities for computing wavelength lookup tables.
 """
 
-import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Generic, NewType
@@ -560,12 +559,14 @@ def _polygon_intersections(polygons: list[np.ndarray], x: np.ndarray) -> np.ndar
     y = np.vstack(
         [np.interp(x, b[:, 0], b[:, 1], left=np.nan, right=np.nan) for b in bounds]
     )
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", category=RuntimeWarning, message="All-NaN slice encountered"
-        )
-        y_min = np.nanmin(y, axis=0)
-        y_max = np.nanmax(y, axis=0)
+    # fmin/fmax reduce ignore NaNs, yielding NaN only for fully-NaN columns (the
+    # expected case of a time bin no subframe covers). This is what nanmin/nanmax
+    # compute internally, minus their all-NaN RuntimeWarning. Avoiding that
+    # warning here sidesteps suppressing it via the process-global, thread-unsafe
+    # warnings.catch_warnings, which races when the workflow runs under a
+    # multi-threaded scheduler.
+    y_min = np.fmin.reduce(y, axis=0)
+    y_max = np.fmax.reduce(y, axis=0)
 
     # Median value and spread estimate
     return 0.5 * (y_min + y_max), 0.5 * (y_max - y_min)

--- a/packages/essreduce/tests/unwrap/lut_test.py
+++ b/packages/essreduce/tests/unwrap/lut_test.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Scipp contributors (https://github.com/scipp)
 from typing import NewType
 
+import numpy as np
 import pytest
 import scipp as sc
 import scippnexus as snx
@@ -10,7 +11,7 @@ from scippneutron.chopper import DiskChopper
 from ess.reduce import unwrap
 from ess.reduce.nexus.types import AnyRun, Position
 from ess.reduce.unwrap import GenericUnwrapWorkflow, LookupTableWorkflow, SourceBounds
-from ess.reduce.unwrap.lut import chopper_distance_along_beam
+from ess.reduce.unwrap.lut import _polygon_intersections, chopper_distance_along_beam
 
 sl = pytest.importorskip("sciline")
 
@@ -468,3 +469,21 @@ def test_analytical_lut_does_not_raise_with_degenerate_polygon():
     # Chopper is 10m from the source, LUT starts at 15m, so no neutrons should make it
     # through. The table should be full of NaNs but should not raise an error.
     assert sc.all(sc.isnan(table.array.data))
+
+
+@pytest.mark.filterwarnings("error::RuntimeWarning")
+def test_polygon_intersections_handles_uncovered_columns_without_warning():
+    # Vertical lines that miss the polygon yield an all-NaN column. Reducing it
+    # must produce NaN (no neutrons at that time) without emitting numpy's
+    # "All-NaN slice encountered" RuntimeWarning: the suppression that warning
+    # would otherwise require is process-global and not thread-safe, so it races
+    # when the workflow runs under a multi-threaded scheduler. The marker turns
+    # any leaked RuntimeWarning into a test failure.
+    triangle = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 1.0]])
+    x = np.array([-0.5, 1.0, 2.5])  # outside, inside, outside
+
+    center, spread = _polygon_intersections([triangle], x)
+
+    # Columns 0 and 2 miss the polygon (all-NaN); column 1 is covered.
+    np.testing.assert_array_equal(np.isnan(center), [True, False, True])
+    np.testing.assert_array_equal(np.isnan(spread), [True, False, True])


### PR DESCRIPTION
Fixes #656.

`_polygon_intersections` reduces the per-bound interpolated wavelengths with `np.nanmin`/`np.nanmax`. An all-NaN column is the expected case of a time bin that no subframe covers, so those reductions legitimately emit numpy's "All-NaN slice encountered" `RuntimeWarning`. Suppressing it required `warnings.catch_warnings`, whose process-global filter state is not thread-safe; under sciline's default dask threaded scheduler, concurrent providers reaching this function race on that state and the warning intermittently leaks. Downstream projects that treat warnings as errors (e.g. esslivedata's wavelength-LUT workflow) then fail flakily.

Reducing with the `fmin`/`fmax` ufuncs directly avoids the problem: they ignore NaNs and yield NaN only for fully-NaN columns — exactly what `nanmin`/`nanmax` compute internally, minus the all-NaN check that emits the warning. No suppression is needed (the `warnings` import is dropped), and it is 2-5x faster as it skips `nanmin`'s NaN-masking copy.

Benchmark (`y` of shape bounds×x, ~20% scattered NaNs + ~15% all-NaN columns):

| shape | `nanmin`/`nanmax` (+catch_warnings) | `fmin.reduce`/`fmax.reduce` |
|---|---|---|
| 4×1000 | 23.8 µs | 5.4 µs |
| 8×1000 | 19.6 µs | 6.1 µs |
| 4×5000 | 33.3 µs | 14.3 µs |
| 20×2000 | 32.7 µs | 17.8 µs |

Results are identical to the previous code (NaN for all-NaN columns, NaN-ignoring min/max otherwise).

## Test plan

- [x] Added a regression test computing `_polygon_intersections` over uncovered (all-NaN) columns under `warnings.simplefilter("error")`.
- [x] `tests/unwrap` passes (141 tests).
