### PR TITLE
[ESSREDUCE] Drop frame_total aux signal

### DIFF
--- a/packages/essreduce/src/ess/reduce/nexus/_nexus_loader.py
+++ b/packages/essreduce/src/ess/reduce/nexus/_nexus_loader.py
@@ -552,7 +552,13 @@ def load_data(
     with open_nexus_file(file_path, definitions=definitions) as f:
         entry = _unique_child_group(f, snx.NXentry, entry_name)
         instrument = _unique_child_group(entry, snx.NXinstrument, None)
+
+        # This only loads the `Group` for the component, it does not build an
+        # `NXdetector`, `NXmonitor`, etc. So this does not use the application
+        # definitions which would drop the data by default. The definitions are
+        # only applied below in `data[sel]`.
         component = instrument[component_name]
+
         if _contains_nx_class(component, snx.NXevent_data):
             data = _unique_child_group(component, snx.NXevent_data, None)
             sel = _to_snx_selection(selection, for_events=True)

--- a/packages/essreduce/src/ess/reduce/nexus/workflow.py
+++ b/packages/essreduce/src/ess/reduce/nexus/workflow.py
@@ -281,6 +281,7 @@ def load_nexus_data(
             entry_name=location.entry_name,
             selection=location.selection,
             component_name=location.component_name,
+            definitions=definitions,
         )
     )
 
@@ -724,6 +725,28 @@ class _StrippedMonitor(snx.NXmonitor):
         super().__init__(attrs=attrs, children=children)
 
 
+class _NXdataWithoutAuxSignals(snx.NXdata):
+    """NXdata definition that drops auxiliary signals.
+
+    This allows us to load, e.g., monitors as data arrays, ignoring the
+    ``frame_total`` auxiliary signal. The frame total has different dimensions
+    from the signal and ScippNeXus would fail because of that.
+    """
+
+    def __init__(
+        self, attrs: dict[str, Any], children: dict[str, snx.Field | snx.Group]
+    ) -> None:
+        # When extending the list, consider instead detecting the signal directly
+        # from `attrs (should be simple for ESS files, no legacy signal definition).
+        # Then we can drop everything that is not the signal or a coord of the signal.
+        children = {
+            key: value
+            for key, value in children.items()
+            if key not in ('frame_total', 'reference_time')
+        }
+        super().__init__(attrs=attrs, children=children)
+
+
 def _add_variances(da: sc.DataArray) -> sc.DataArray:
     out = da.copy(deep=False)
     if out.bins is not None:
@@ -783,6 +806,7 @@ def load_source_metadata_from_nexus(
 definitions = snx.base_definitions()
 definitions["NXdetector"] = _StrippedDetector
 definitions["NXmonitor"] = _StrippedMonitor
+definitions['NXdata'] = _NXdataWithoutAuxSignals
 
 _common_providers = (
     gravity_vector_neg_y,


### PR DESCRIPTION
ESS histogram monitors now contain a frame_time auxiliary signal which has different dims from the monitor's main signal. That fails the ScippNeXus loader.

This change works around that by not loading the frame_total in workflows. This is a partial implementation of https://github.com/scipp/scippnexus/issues/304