### PR TITLE
[CI] Remove draft release CI step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,24 +99,6 @@ jobs:
         with:
           packages-dir: dist/
 
-  draft-release:
-    name: Draft a release or/and check the release
-    needs: [ determine-package ]
-    runs-on: ubuntu-slim
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'workflow_dispatch' }}
-    permissions:
-      contents: write
-    env:
-      TAG: ${{ needs.determine-package.outputs.package }}/${{ needs.determine-package.outputs.version }}
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Draft a release.
-        run: gh release create ${TAG} --draft --title ${TAG}  # Default title is not always the tag name.
-        continue-on-error: true  # Release create can fail if there is an existing release.
-      - name: Check the release.
-        run: gh release view ${TAG}  # This command should not fail if the release already exists or was created by the previous step.
-
   docs:
     name: Build and publish docs
     needs: [ determine-package, publish ]
@@ -130,7 +112,7 @@ jobs:
 
   assets:
     name: Upload docs
-    needs: [ docs, determine-package, draft-release ]
+    needs: [ docs, determine-package ]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -154,7 +136,7 @@ jobs:
 
   notes:
     name: Update notes
-    needs: [ determine-package, draft-release ]
+    needs: [ determine-package ]
     runs-on: ubuntu-slim
     if: ${{ always() && needs.determine-package.outputs.lastversion }}
     permissions:
@@ -203,4 +185,4 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md" --draft=false  # Publish the release with the new note.
+        run: gh release edit ${PACKAGE}/${VERSION} --notes-file "new-release-note.md"


### PR DESCRIPTION
The draft release step when making a release goes wrong when we make a release via the web UI.

A draft release with the same name using the same tag is created alongside the release already created by the web UI.
<img width="946" height="1096" alt="Screenshot_20260703_132021" src="https://github.com/user-attachments/assets/d7bbb41b-15cc-49dd-9044-06aa30b8e08a" />

Then, the release notes of the non-draft release get updated.
The uploading of the docs as assets fails.
The draft release never gets promoted to non-draft, because the original release gets picked up by the `gh` command.

For now, we remove this step, meaning that releases should only be created via the web interface (simply pushing a tag from the CLI will no longer work).
We should revisit once everyone is back from vacation.