### PR TITLE
[ESSDIFFRACTION] Fix multiplication with mask

### DIFF
--- a/packages/essdiffraction/src/ess/dream/io/_common.py
+++ b/packages/essdiffraction/src/ess/dream/io/_common.py
@@ -14,13 +14,8 @@ def prepare_reduced_data(da: sc.DataArray) -> sc.DataArray:
     hist.coords[hist.dim] = sc.midpoints(hist.coords[hist.dim])
 
     if (mask := irreducible_mask(hist.masks, hist.dim)) is not None:
-        # No file format we use here supports masks, so the next
-        # best thing is to zero out masked data:
-        if hist.variances is not None:
-            replacement = sc.scalar(0.0, variance=0.0, unit=hist.unit, dtype=hist.dtype)
-        else:
-            replacement = sc.scalar(0.0, unit=hist.unit, dtype=hist.dtype)
-        hist.data = sc.where(mask, replacement, hist.data)
+        # No file format we use here supports masks, so we remove masked data points
+        hist = hist[~mask]
         hist.masks.clear()
 
     return hist

--- a/packages/essdiffraction/src/ess/dream/io/_common.py
+++ b/packages/essdiffraction/src/ess/dream/io/_common.py
@@ -17,7 +17,10 @@ def prepare_reduced_data(da: sc.DataArray) -> sc.DataArray:
         # No file format we use here supports masks, so the next
         # best thing is to zero out masked data:
         hist.data = hist.data.copy()
-        hist.values *= irreducible_mask(hist.masks, hist.dim).values
+        mask_factor = ~irreducible_mask(hist.masks, hist.dim).values
+        hist.values *= mask_factor
+        if hist.variances is not None:
+            hist.variances *= mask_factor
         hist.masks.clear()
 
     return hist

--- a/packages/essdiffraction/src/ess/dream/io/_common.py
+++ b/packages/essdiffraction/src/ess/dream/io/_common.py
@@ -13,14 +13,14 @@ def prepare_reduced_data(da: sc.DataArray) -> sc.DataArray:
     hist = da.hist() if da.is_binned else da.copy(deep=False)
     hist.coords[hist.dim] = sc.midpoints(hist.coords[hist.dim])
 
-    if hist.masks:
+    if (mask := irreducible_mask(hist.masks, hist.dim)) is not None:
         # No file format we use here supports masks, so the next
         # best thing is to zero out masked data:
-        hist.data = hist.data.copy()
-        mask_factor = ~irreducible_mask(hist.masks, hist.dim).values
-        hist.values *= mask_factor
         if hist.variances is not None:
-            hist.variances *= mask_factor
+            replacement = sc.scalar(0.0, variance=0.0, unit=hist.unit, dtype=hist.dtype)
+        else:
+            replacement = sc.scalar(0.0, unit=hist.unit, dtype=hist.dtype)
+        hist.data = sc.where(mask, replacement, hist.data)
         hist.masks.clear()
 
     return hist

--- a/packages/essdiffraction/tests/dream/io/cif_test.py
+++ b/packages/essdiffraction/tests/dream/io/cif_test.py
@@ -4,8 +4,10 @@ import datetime
 import io
 
 import ess.dream.io.cif
+import numpy as np
 import pytest
 import scipp as sc
+import scipp.testing
 from ess.powder.calibration import OutputCalibrationData
 from ess.powder.types import (
     Beamline,
@@ -23,8 +25,11 @@ from scippneutron.metadata import ESS_SOURCE, Person
 def ioftof() -> IntensityTof:
     return IntensityTof(
         sc.DataArray(
-            sc.array(dims=['tof'], values=[2.1, 3.2], variances=[0.3, 0.4]),
-            coords={'tof': sc.linspace('tof', 0.1, 1.2, 3, unit='us')},
+            sc.array(dims=['tof'], values=[2.1, 3.2, 1.6], variances=[0.3, 0.4, 0.1]),
+            coords={
+                'tof': sc.array(dims=['tof'], values=[0.1, 0.3, 0.5, 0.7], unit='us')
+            },
+            masks={'bad': sc.array(dims=['tof'], values=[False, True, False])},
         )
     )
 
@@ -95,3 +100,42 @@ _pd_proc.intensity_norm
 _pd_proc.intensity_norm_su
 """
     assert loop_header in result
+
+
+def test_save_reduced_tof_writes_excpected_data(
+    ioftof: IntensityTof, cal: OutputCalibrationData
+) -> None:
+    cif_ = ess.dream.io.cif.prepare_reduced_tof_cif(
+        ioftof,
+        authors=CIFAuthors([]),
+        beamline=Beamline(
+            name="DREAM",
+        ),
+        source=ESS_SOURCE,
+        measurement=Measurement(
+            title="Test measurement",
+        ),
+        reducers=ReducerSoftware([]),
+        calibration=cal,
+    )
+    result = save_reduced_tof_to_str(cif_)
+
+    loop_header = """loop_
+_pd_data.point_id
+_pd_meas.time_of_flight
+_pd_proc.intensity_norm
+_pd_proc.intensity_norm_su
+"""
+    data_table = result[result.index(loop_header) + len(loop_header) :]
+    _, tof, val, std = np.loadtxt(io.StringIO(data_table), delimiter=' ').T
+    loaded = sc.DataArray(
+        sc.array(dims=['tof'], values=val, variances=std**2),
+        coords={'tof': sc.array(dims=['tof'], values=tof, unit='us')},
+    )
+
+    expected = sc.DataArray(
+        sc.array(dims=['tof'], values=[2.1, 0.0, 1.6], variances=[0.3, 0.0, 0.1]),
+        coords={'tof': sc.array(dims=['tof'], values=[0.2, 0.4, 0.6], unit='us')},
+    )
+    # Can't be identical because of conversion to standard deviations
+    sc.testing.assert_allclose(loaded, expected)

--- a/packages/essdiffraction/tests/dream/io/cif_test.py
+++ b/packages/essdiffraction/tests/dream/io/cif_test.py
@@ -133,9 +133,10 @@ _pd_proc.intensity_norm_su
         coords={'tof': sc.array(dims=['tof'], values=tof, unit='us')},
     )
 
+    # Only 2 data points are expected because one of the 3 points is masked
     expected = sc.DataArray(
-        sc.array(dims=['tof'], values=[2.1, 0.0, 1.6], variances=[0.3, 0.0, 0.1]),
-        coords={'tof': sc.array(dims=['tof'], values=[0.2, 0.4, 0.6], unit='us')},
+        sc.array(dims=['tof'], values=[2.1, 1.6], variances=[0.3, 0.1]),
+        coords={'tof': sc.array(dims=['tof'], values=[0.2, 0.6], unit='us')},
     )
     # Can't be identical because of conversion to standard deviations
     sc.testing.assert_allclose(loaded, expected)


### PR DESCRIPTION
I messed this up in #673

- ~Zero out masked elements, not unmasked ones~ keep unmasked elements
- ~Apply mask to variances~
- ~use `sc.where` instead of multiplication because the latter does not work when the data is Inf or NaN.~
- Add test to check written data

**Update:** analysis team suggested that masked values should simply be removed from the file written to disk, instead of replacing with zeros or NaNs.
This has the advantage of circumventing the issue with what to do with the variances.