### PR TITLE
[CI] Report nightly weekly test failures in issue board.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -200,6 +200,6 @@ jobs:
           if [ -z ${number} ]; then
             echo "No issue opened."
           else
-            gh issue close -r completed \
+            gh issue close ${number} -r completed \
             -c "Nightly fixed at https://github.com/scipp/ess/actions/runs/${{ github.run_id }}"
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,7 +175,7 @@ jobs:
           if [ -z ${number} ]; then
             today=$(date -I)
             title="Nightly Failures ${today}"
-            gh issue create -t "Nightly Failure ${title}" \
+            gh issue create -t "${title}" \
               -l nightly-failure \
               -b "See https://github.com/scipp/ess/actions/runs/${{ github.run_id }} for more details."
           else

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Open an issue with the link to the failing test results.
         run: |
           number=$(gh issue list -l nightly-failure --json number -q ".[0].number")
-          if [ -z ${number) ]; then
+          if [ -z ${number} ]; then
             today=$(date -I)
             title="Nightly Failures ${today}"
             gh issue create -t "Nightly Failure ${title}" \
@@ -196,7 +196,7 @@ jobs:
       - name: Close the issue about the nightly failure.
         run: |
           number=$(gh issue list -l nightly-failure --json number -q ".[0].number")
-          if [ -z ${number) ]; then
+          if [ -z ${number} ]; then
             echo "No issue opened."
           else
             gh issue close -r completed \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
           name: reduced-data-${{ matrix.package }}
           path: tests_outputs/
           if-no-files-found: warn
-  
+
   publish:
     name: Publish nightly reduced data
     needs: test

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -183,9 +183,10 @@ jobs:
           fi
 
   report-test-success:
-    name: Report nightly failures
+    name: Report nightly success
     needs: [ test, publish, lower-bound, latest-dependencies ]
     runs-on: ubuntu-slim
+    if: github.ref == 'refs/heads/main'
     env:
        GH_TOKEN: ${{ github.token }}
     permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
           name: reduced-data-${{ matrix.package }}
           path: tests_outputs/
           if-no-files-found: warn
-
+  
   publish:
     name: Publish nightly reduced data
     needs: test
@@ -156,3 +156,49 @@ jobs:
       - name: Test with latest dependencies
         working-directory: packages/${{ matrix.package }}
         run: uv run --extra=test --resolution=highest pytest
+
+  report-test-failure:
+    name: Report nightly failures
+    needs: [ test, publish, lower-bound, latest-dependencies ]
+    runs-on: ubuntu-slim
+    if: failure() && github.event_name == 'schedule'
+    env:
+       GH_TOKEN: ${{ github.token }}
+    permissions:
+      # The nightly failure opens an issue.
+      issues: write
+    steps:
+      - uses: actions/checkout@v6.1.0
+      - name: Open an issue with the link to the failing test results.
+        run: |
+          number=$(gh issue list -l nightly-failure --json number -q ".[0].number")
+          if [ -z ${number) ]; then
+            today=$(date -I)
+            title="Nightly Failures ${today}"
+            gh issue create -t "Nightly Failure ${title}" \
+              -l nightly-failure \
+              -b "See https://github.com/scipp/ess/actions/runs/${{ github.run_id }} for more details."
+          else
+            echo "An issue already exists for nightly failure: #${number}"
+          fi
+
+  report-test-success:
+    name: Report nightly failures
+    needs: [ test, publish, lower-bound, latest-dependencies ]
+    runs-on: ubuntu-slim
+    env:
+       GH_TOKEN: ${{ github.token }}
+    permissions:
+      # The nightly success closes an issue if needed.
+      issues: write
+    steps:
+      - uses: actions/checkout@v6.1.0
+      - name: Close the issue about the nightly failure.
+        run: |
+          number=$(gh issue list -l nightly-failure --json number -q ".[0].number")
+          if [ -z ${number) ]; then
+            echo "No issue opened."
+          else
+            gh issue close -r completed \
+            -c "Nightly fixed at https://github.com/scipp/ess/actions/runs/${{ github.run_id }}"
+          fi

--- a/.github/workflows/weekly-platform.yml
+++ b/.github/workflows/weekly-platform.yml
@@ -36,3 +36,50 @@ jobs:
           environments: ${{ matrix.package }}
       - name: Run tests
         run: pixi run -e ${{ matrix.package }} test ${{ matrix.package }}
+
+  report-test-failure:
+    name: Report weekly failures
+    needs: test
+    runs-on: ubuntu-slim
+    if: failure() && github.event_name == 'schedule'
+    env:
+       GH_TOKEN: ${{ github.token }}
+    permissions:
+      # The weekly failure opens an issue.
+      issues: write
+    steps:
+      - uses: actions/checkout@v6.1.0
+      - name: Open an issue with the link to the failing test results.
+        run: |
+          number=$(gh issue list -l weekly-failure --json number -q ".[0].number")
+          if [ -z ${number} ]; then
+            today=$(date -I)
+            title="Weekly Platform Test Failures ${today}"
+            gh issue create -t "${title}" \
+              -l weekly-failure \
+              -b "See https://github.com/scipp/ess/actions/runs/${{ github.run_id }} for more details."
+          else
+            echo "An issue already exists for weekly failure: #${number}"
+          fi
+
+  report-test-success:
+    name: Report weekly success
+    needs: test
+    runs-on: ubuntu-slim
+    if: github.ref == 'refs/heads/main'
+    env:
+       GH_TOKEN: ${{ github.token }}
+    permissions:
+      # The weekly success closes an issue if needed.
+      issues: write
+    steps:
+      - uses: actions/checkout@v6.1.0
+      - name: Close the issue about the weekly failure.
+        run: |
+          number=$(gh issue list -l weekly-failure --json number -q ".[0].number")
+          if [ -z ${number} ]; then
+            echo "No issue opened."
+          else
+            gh issue close ${number} -r completed \
+            -c "Weekly Platform tests fixed at https://github.com/scipp/ess/actions/runs/${{ github.run_id }}"
+          fi


### PR DESCRIPTION
It was tested in these runs:

# Creat an issue on failure

It created the issue #682 (I fixed the title in this branch)
https://github.com/scipp/ess/actions/runs/30393729000

# When the issue already exists about nightly failure

It doesn't create a new issue but prints out the existing issue number
https://github.com/scipp/ess/actions/runs/30393832476

# Close an open issue when all tests succeed

It closes an existing open issue with the `nightly-failure` label #681 
https://github.com/scipp/ess/actions/runs/30393487225/job/90390714701

When there is no open issue, it does nothing.
https://github.com/scipp/ess/actions/runs/30393487225/job/90391008068