### PR TITLE
[ESSNMX] Fix weekly test for NMX

### DIFF
--- a/packages/essnmx/src/ess/nmx/executables.py
+++ b/packages/essnmx/src/ess/nmx/executables.py
@@ -340,6 +340,11 @@ def save_results(
     aux_config: AuxiliaryOutputConfig | None = None,
     display: Callable | None = None,
 ) -> None:
+    import matplotlib
+
+    # Plots will be saved into png files
+    # therefore it does not need to have interactive backend.
+    matplotlib.use("Agg")
     aux_config = aux_config or AuxiliaryOutputConfig()
     output_file_path = pathlib.Path(output_config.output_file).resolve()
     aux_output_dir = aux_config.build_target_dir(output_file_path.as_posix())

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -31,7 +31,10 @@ try:
     # so that h5py can use the plugin.
     import bitshuffle.h5  # noqa: F401
 except ImportError:
-    ...
+    pytest.skip(
+        allow_module_level=True,
+        reason="File output regression test cannot be done without `bitshuffle.h5`.",
+    )
 
 
 def assert_h5_attrs_equal(

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -26,15 +26,10 @@ from ess.nmx.data import get_small_nmx_nexus, get_small_nmx_reduced
 from ess.nmx.executables import reduction
 from ess.nmx.types import Compression
 
-try:
-    # The bitshuffle plugin needs to be imported at least once in the session
-    # so that h5py can use the plugin.
-    import bitshuffle.h5  # noqa: F401
-except ImportError:
-    pytest.skip(
-        allow_module_level=True,
-        reason="File output regression test cannot be done without `bitshuffle.h5`.",
-    )
+pytest.importorskip(
+    "bitshuffle.h5",
+    reason="File output regression test cannot be done without `bitshuffle.h5`.",
+)
 
 
 def assert_h5_attrs_equal(

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -26,6 +26,8 @@ from ess.nmx.data import get_small_nmx_nexus, get_small_nmx_reduced
 from ess.nmx.executables import reduction
 from ess.nmx.types import Compression
 
+# The bitshuffle plugin needs to be imported at least once in the session
+# so that h5py can use the plugin.
 pytest.importorskip(
     "bitshuffle.h5",
     reason="File output regression test cannot be done without `bitshuffle.h5`.",

--- a/packages/essnmx/tests/executable_output_test.py
+++ b/packages/essnmx/tests/executable_output_test.py
@@ -9,9 +9,6 @@ and update the frozen file in the `ess.nmx.data` registry.
 
 import pathlib
 
-# The bitshuffle plugin needs to be imported at least once in the session
-# so that h5py can use the plugin.
-import bitshuffle.h5  # noqa: F401
 import h5py
 import numpy as np
 import pytest
@@ -28,6 +25,13 @@ from ess.nmx.configurations import (
 from ess.nmx.data import get_small_nmx_nexus, get_small_nmx_reduced
 from ess.nmx.executables import reduction
 from ess.nmx.types import Compression
+
+try:
+    # The bitshuffle plugin needs to be imported at least once in the session
+    # so that h5py can use the plugin.
+    import bitshuffle.h5  # noqa: F401
+except ImportError:
+    ...
 
 
 def assert_h5_attrs_equal(

--- a/packages/essnmx/tests/mcstas/exporter_test.py
+++ b/packages/essnmx/tests/mcstas/exporter_test.py
@@ -55,11 +55,10 @@ def reduced_data() -> NMXReducedDataGroup:
 
 
 def _is_bitshuffle_available() -> bool:
-    import platform
-
-    return not (
-        platform.machine().startswith("arm") or platform.platform().startswith('win')
-    )
+    try:
+        import bitshuffle.h5  # noqa: F401
+    except ImportError:
+        return False
 
 
 def test_mcstas_reduction_export_to_bytestream(

--- a/packages/essnmx/tests/mcstas/exporter_test.py
+++ b/packages/essnmx/tests/mcstas/exporter_test.py
@@ -59,6 +59,8 @@ def _is_bitshuffle_available() -> bool:
         import bitshuffle.h5  # noqa: F401
     except ImportError:
         return False
+    else:
+        return True
 
 
 def test_mcstas_reduction_export_to_bytestream(


### PR DESCRIPTION
It was just because of the bitshuffle.h5 ...

I tested manually https://github.com/scipp/ess/actions/runs/30463403880

The other issue was that the plotting was done with interactive backend in the windows.
I just set the default backend to be `Agg` for NMX executable since it only dumps PNG files.
It's already a known issue: https://github.com/scipp/plopp/issues/516