### PR TITLE
[CI] ci: use agg backend in weekly tests

### DIFF
--- a/.github/workflows/weekly-platform.yml
+++ b/.github/workflows/weekly-platform.yml
@@ -6,6 +6,7 @@ on:
     - cron: "0 2 * * 1"
 
 env:
+  MPLBACKEND: Agg
   PIXI_FROZEN: true
   PIXI_NO_INSTALL: true
 


### PR DESCRIPTION
Fixes https://github.com/scipp/ess/actions/runs/30788032517/job/91605473714

This uses agg backend on all platforms even though I think it only fails intermittently on windows.