### PR TITLE
[ESSSPECTROSCOPY] Source the BIFROST Bragg peak monitor from the NXmonitor

### DIFF
--- a/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-bragg-peak-monitor.ipynb
+++ b/packages/essspectroscopy/docs/user-guide/bifrost/bifrost-bragg-peak-monitor.ipynb
@@ -29,7 +29,6 @@
     "from ess.bifrost.single_crystal import BifrostSimulationBraggPeakMonitorWorkflow, make_q_map\n",
     "from ess.bifrost.single_crystal.types import *\n",
     "from ess.bifrost.types import McStasRawDetector\n",
-    "from ess.reduce.unwrap import DetectorLtotal\n",
     "from ess.spectroscopy.types import *"
    ]
   },
@@ -113,24 +112,7 @@
     "    return McStasRawDetector[RunType](monitor)\n",
     "\n",
     "\n",
-    "def detector_ltotal_from_straight_line_approximation(\n",
-    "        detector_beamline: RawDetector[RunType],\n",
-    "        source_position: Position[snx.NXsource, RunType],\n",
-    "        sample_position: Position[snx.NXsample, RunType],\n",
-    "        gravity: GravityVector,\n",
-    ") -> DetectorLtotal[RunType]:\n",
-    "    from ess.reduce.unwrap import to_wavelength\n",
-    "    return to_wavelength.detector_ltotal_from_straight_line_approximation(\n",
-    "        detector_beamline,  # type: ignore[arg-type]\n",
-    "\n",
-    "        source_position=source_position,\n",
-    "        sample_position=sample_position,\n",
-    "        gravity=gravity,\n",
-    "    )\n",
-    "\n",
-    "\n",
-    "workflow.insert(assemble_detector_data_flatten)\n",
-    "workflow.insert(detector_ltotal_from_straight_line_approximation)"
+    "workflow.insert(assemble_detector_data_flatten)"
    ]
   },
   {

--- a/packages/essspectroscopy/src/ess/bifrost/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/detector.py
@@ -11,7 +11,6 @@ import scippnexus as snx
 from ess.spectroscopy.indirect.conversion import add_spectrometer_coords
 from ess.spectroscopy.types import (
     Analyzer,
-    DetectorPositionOffset,
     EmptyDetector,
     NeXusComponent,
     NeXusTransformation,
@@ -86,7 +85,6 @@ def get_calibrated_detector_bifrost(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
     primary_graph: PrimarySpecCoordTransformGraph[RunType],
     secondary_graph: SecondarySpecCoordTransformGraph[RunType],
 ) -> EmptyDetector[RunType]:
@@ -107,8 +105,6 @@ def get_calibrated_detector_bifrost(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
     primary_graph:
         Coordinate transformation graph for the primary spectrometer.
     secondary_graph:
@@ -122,9 +118,7 @@ def get_calibrated_detector_bifrost(
         Detector geometry and spectrometer coordinates.
     """
 
-    da = get_base_calibrated_detector_bifrost(
-        detector, analyzer, transform=transform, offset=offset
-    )
+    da = get_base_calibrated_detector_bifrost(detector, analyzer, transform=transform)
     da = da.rename(dim_0='tube', dim_1='length')
 
     arc, channel = arc_and_channel_from_detector_number(da.coords['detector_number'])
@@ -147,7 +141,6 @@ def get_base_calibrated_detector_bifrost(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
 ) -> sc.DataArray:
     """Extract the data array corresponding to a detector's signal field.
 
@@ -163,8 +156,6 @@ def get_base_calibrated_detector_bifrost(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
 
     Returns
     -------
@@ -173,9 +164,14 @@ def get_base_calibrated_detector_bifrost(
     """
 
     from ess.reduce.nexus import compute_detector_position, extract_signal_data_array
+    from ess.reduce.nexus.workflow import no_offset
 
     da = extract_signal_data_array(detector)
-    position = compute_detector_position(da, transform=transform, offset=offset)
+    # BIFROST's detectors ride the rotating tank, so a lab-frame offset added after
+    # the transform cannot express any correction one would actually want; the
+    # transformation chain is the handle. compute_detector_position requires the
+    # argument, so pin it to zero here.
+    position = compute_detector_position(da, transform=transform, offset=no_offset)
     return _assign_detector_position(da, position)
 
 

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -1,19 +1,90 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Scipp contributors (https://github.com/scipp)
 
-"""Bragg peak detector handling for BIFROST."""
+"""Bragg peak monitor handling for BIFROST."""
 
+import scipp as sc
 import scippnexus as snx
 from ess.spectroscopy.types import (
     Analyzer,
     DetectorPositionOffset,
+    ElasticMonitor,
     EmptyDetector,
     NeXusComponent,
+    NeXusData,
     NeXusTransformation,
+    RawDetector,
     RunType,
 )
 
-from ..detector import get_base_calibrated_detector_bifrost
+from ess.reduce.nexus.types import MonitorPositionOffset
+
+from ..detector import _assign_detector_position, get_base_calibrated_detector_bifrost
+
+
+def get_calibrated_bragg_peak_monitor(
+    monitor: NeXusComponent[ElasticMonitor, RunType],
+    *,
+    transform: NeXusTransformation[ElasticMonitor, RunType],
+    offset: MonitorPositionOffset[RunType, ElasticMonitor],
+) -> EmptyDetector[RunType]:
+    """Extract the data array corresponding to the Bragg peak monitor's signal field.
+
+    BIFROST's Bragg peak monitor is the elastic monitor (``cbm5``), written as an
+    ``NXmonitor``. It has no pixel offsets, so its position is the transformed origin
+    as in :func:`ess.reduce.nexus.workflow.get_calibrated_monitor`, rather than the
+    per-pixel computation used for detectors. The position is assigned with the
+    BIFROST-specific broadcasting because the monitor is mounted on the detector tank
+    and therefore moves with the instrument angle.
+
+    Parameters
+    ----------
+    monitor:
+        Loaded NeXus monitor.
+    transform:
+        Transformation that determines the monitor position.
+    offset:
+        Offset to add to the monitor position.
+
+    Returns
+    -------
+    :
+        Monitor with geometry coordinates.
+    """
+    from ess.reduce.nexus import extract_signal_data_array
+
+    da = extract_signal_data_array(monitor)
+    unit = transform.value.unit
+    position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit) + offset.to(
+        unit=unit
+    )
+    # A monitor carries no detector_number; the Bragg peak monitor is a single pixel,
+    # so name it explicitly for the pixel-grouping done by the event assembly below.
+    da = da.assign_coords(detector_number=sc.index(1))
+    return EmptyDetector[RunType](_assign_detector_position(da, position))
+
+
+def assemble_bragg_peak_monitor_data(
+    monitor: EmptyDetector[RunType],
+    data: NeXusData[ElasticMonitor, RunType],
+) -> RawDetector[RunType]:
+    """Combine the Bragg peak monitor's geometry with its event data.
+
+    Parameters
+    ----------
+    monitor:
+        Monitor geometry from :func:`get_calibrated_bragg_peak_monitor`.
+    data:
+        Monitor event data.
+
+    Returns
+    -------
+    :
+        Events with geometry coordinates.
+    """
+    from ess.reduce.nexus.workflow import assemble_detector_data
+
+    return RawDetector[RunType](assemble_detector_data(monitor, data))
 
 
 def get_calibrated_bragg_peak_detector(
@@ -23,7 +94,11 @@ def get_calibrated_bragg_peak_detector(
     transform: NeXusTransformation[snx.NXdetector, RunType],
     offset: DetectorPositionOffset[RunType],
 ) -> EmptyDetector[RunType]:
-    """Extract the data array corresponding to the Bragg peak detector's signal field.
+    """Extract the data array corresponding to a detector's signal field.
+
+    Simulated data contains no Bragg peak monitor, so a bank ('triplet') of the
+    regular inelastic detector stands in for it. Real data uses
+    :func:`get_calibrated_bragg_peak_monitor` instead.
 
     Parameters
     ----------
@@ -46,4 +121,5 @@ def get_calibrated_bragg_peak_detector(
     )
 
 
-providers = (get_calibrated_bragg_peak_detector,)
+providers = (get_calibrated_bragg_peak_monitor, assemble_bragg_peak_monitor_data)
+simulation_providers = (get_calibrated_bragg_peak_detector,)

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -82,9 +82,13 @@ def assemble_bragg_peak_monitor_data(
     :
         Events with geometry coordinates.
     """
-    from ess.reduce.nexus.workflow import assemble_detector_data
+    from ess.reduce.nexus.workflow import _add_variances
 
-    return RawDetector[RunType](assemble_detector_data(monitor, data))
+    # Not ``assemble_detector_data``: that groups events by ``event_id``, which a
+    # monitor does not carry. The Bragg peak monitor is a single pixel, so its
+    # geometry is simply assigned onto the events, as for any other monitor.
+    da = data.assign_coords(monitor.coords).assign_masks(monitor.masks)
+    return RawDetector[RunType](_add_variances(da))
 
 
 def get_calibrated_bragg_peak_detector(

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -26,7 +26,8 @@ def get_calibrated_bragg_peak_monitor(
 ) -> EmptyDetector[RunType]:
     """Extract the data array corresponding to the Bragg peak monitor's signal field.
 
-    BIFROST's Bragg peak monitor is the elastic monitor (``cbm5``), written as an
+    BIFROST's Bragg peak monitor is the elastic monitor, named ``elastic_monitor``
+    in NeXus files (``cbm5`` in instrument documentation) and written as an
     ``NXmonitor``. It has no pixel offsets, so its position is the transformed origin
     as in :func:`ess.reduce.nexus.workflow.get_calibrated_monitor`, rather than the
     per-pixel computation used for detectors. The position is assigned with the
@@ -63,8 +64,8 @@ def assemble_bragg_peak_monitor_data(
     events by ``event_id`` onto a ``detector_number`` grid, and the Bragg peak
     monitor is a single pixel with nothing to group by. Its geometry is therefore
     assigned straight onto the events. The result is the same whether or not the
-    events carry an ``event_id`` -- a file-loaded ``cbm5_events`` group does, a
-    stream may not -- because the coordinate is simply left untouched.
+    events carry an ``event_id`` -- the event group in a file does, a stream may
+    not -- because the coordinate is simply left untouched.
 
     Parameters
     ----------

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -7,7 +7,6 @@ import scipp as sc
 import scippnexus as snx
 from ess.spectroscopy.types import (
     Analyzer,
-    DetectorPositionOffset,
     ElasticMonitor,
     EmptyDetector,
     NeXusComponent,
@@ -17,8 +16,6 @@ from ess.spectroscopy.types import (
     RunType,
 )
 
-from ess.reduce.nexus.types import MonitorPositionOffset
-
 from ..detector import _assign_detector_position, get_base_calibrated_detector_bifrost
 
 
@@ -26,7 +23,6 @@ def get_calibrated_bragg_peak_monitor(
     monitor: NeXusComponent[ElasticMonitor, RunType],
     *,
     transform: NeXusTransformation[ElasticMonitor, RunType],
-    offset: MonitorPositionOffset[RunType, ElasticMonitor],
 ) -> EmptyDetector[RunType]:
     """Extract the data array corresponding to the Bragg peak monitor's signal field.
 
@@ -43,8 +39,6 @@ def get_calibrated_bragg_peak_monitor(
         Loaded NeXus monitor.
     transform:
         Transformation that determines the monitor position.
-    offset:
-        Offset to add to the monitor position.
 
     Returns
     -------
@@ -55,9 +49,7 @@ def get_calibrated_bragg_peak_monitor(
 
     da = extract_signal_data_array(monitor)
     unit = transform.value.unit
-    position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit) + offset.to(
-        unit=unit
-    )
+    position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit)
     return EmptyDetector[RunType](_assign_detector_position(da, position))
 
 
@@ -96,7 +88,6 @@ def get_calibrated_bragg_peak_detector(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
 ) -> EmptyDetector[RunType]:
     """Extract the data array corresponding to a detector's signal field.
 
@@ -112,17 +103,13 @@ def get_calibrated_bragg_peak_detector(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
 
     Returns
     -------
     :
         Detector with geometry coordinates.
     """
-    return get_base_calibrated_detector_bifrost(
-        detector, analyzer, transform=transform, offset=offset
-    )
+    return get_base_calibrated_detector_bifrost(detector, analyzer, transform=transform)
 
 
 providers = (get_calibrated_bragg_peak_monitor, assemble_bragg_peak_monitor_data)

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -58,9 +58,6 @@ def get_calibrated_bragg_peak_monitor(
     position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit) + offset.to(
         unit=unit
     )
-    # A monitor carries no detector_number; the Bragg peak monitor is a single pixel,
-    # so name it explicitly for the pixel-grouping done by the event assembly below.
-    da = da.assign_coords(detector_number=sc.index(1))
     return EmptyDetector[RunType](_assign_detector_position(da, position))
 
 
@@ -69,6 +66,13 @@ def assemble_bragg_peak_monitor_data(
     data: NeXusData[ElasticMonitor, RunType],
 ) -> RawDetector[RunType]:
     """Combine the Bragg peak monitor's geometry with its event data.
+
+    Assembled as a monitor, not as a detector: ``assemble_detector_data`` groups
+    events by ``event_id`` onto a ``detector_number`` grid, and the Bragg peak
+    monitor is a single pixel with nothing to group by. Its geometry is therefore
+    assigned straight onto the events. The result is the same whether or not the
+    events carry an ``event_id`` -- a file-loaded ``cbm5_events`` group does, a
+    stream may not -- because the coordinate is simply left untouched.
 
     Parameters
     ----------
@@ -82,13 +86,9 @@ def assemble_bragg_peak_monitor_data(
     :
         Events with geometry coordinates.
     """
-    from ess.reduce.nexus.workflow import _add_variances
+    from ess.reduce.nexus.workflow import assemble_monitor_data
 
-    # Not ``assemble_detector_data``: that groups events by ``event_id``, which a
-    # monitor does not carry. The Bragg peak monitor is a single pixel, so its
-    # geometry is simply assigned onto the events, as for any other monitor.
-    da = data.assign_coords(monitor.coords).assign_masks(monitor.masks)
-    return RawDetector[RunType](_add_variances(da))
+    return RawDetector[RunType](assemble_monitor_data(monitor, data))
 
 
 def get_calibrated_bragg_peak_detector(

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/time_of_flight.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/time_of_flight.py
@@ -32,6 +32,13 @@ def detector_wavelength_data(
     :func:`ess.reduce.unwrap.detector_wavelength_data`
     for different input types.
     """
+    # A time-dependent detector position (BIFROST's tank rotates, and the Bragg peak
+    # monitor is mounted on it) makes ``ltotal`` depend on 'time'. The instrument angle
+    # is the only dynamic parameter, so ``group_by_rotation`` has already turned that
+    # same 'time' dimension into 'a4'. Rename to match, or the broadcast below rejects
+    # ``ltotal`` as having a dimension the data does not.
+    if 'time' in ltotal.dims and 'time' not in sample_data.dims:
+        ltotal = ltotal.rename_dims(time='a4')
     return reduce_unwrap.to_wavelength.detector_wavelength_data(
         detector_data=RawDetector[RunType](sample_data),
         lookup=lookup,

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/time_of_flight.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/time_of_flight.py
@@ -6,7 +6,10 @@
 import scippnexus as snx
 from ess.spectroscopy.types import (
     DataGroupedByRotation,
+    EmptyDetector,
     ErrorLimitedLookupTable,
+    GravityVector,
+    Position,
     PulseStrideOffset,
     RawDetector,
     RunType,
@@ -15,6 +18,36 @@ from ess.spectroscopy.types import (
 
 from ess.reduce import unwrap as reduce_unwrap
 from ess.reduce.unwrap.types import DetectorLtotal
+
+
+def detector_ltotal(
+    sample_data: DataGroupedByRotation[RunType],
+    source_position: Position[snx.NXsource, RunType],
+    sample_position: Position[snx.NXsample, RunType],
+    gravity: GravityVector,
+) -> DetectorLtotal[RunType]:
+    """
+    Compute Ltotal from the straight-line approximation.
+
+    The Bragg peak monitor views the beam direct from the sample, without an analyzer
+    in between, so a straight line is the correct flight path.
+
+    Computed after grouping so that ``Ltotal`` carries the dimensions of the grouped
+    data. BIFROST's tank rotates and the Bragg peak monitor is mounted on it, so the
+    monitor position -- and hence ``Ltotal`` -- is time-dependent; ``group_by_rotation``
+    turns that 'time' dimension into 'a4'. Deriving ``Ltotal`` from the ungrouped
+    geometry instead would leave it labelled with a dimension the data no longer has.
+
+    This is a wrapper around
+    :func:`ess.reduce.unwrap.detector_ltotal_from_straight_line_approximation`
+    for different input types.
+    """
+    return reduce_unwrap.to_wavelength.detector_ltotal_from_straight_line_approximation(
+        detector=EmptyDetector[RunType](sample_data),
+        source_position=source_position,
+        sample_position=sample_position,
+        gravity=gravity,
+    )
 
 
 def detector_wavelength_data(
@@ -32,13 +65,6 @@ def detector_wavelength_data(
     :func:`ess.reduce.unwrap.detector_wavelength_data`
     for different input types.
     """
-    # A time-dependent detector position (BIFROST's tank rotates, and the Bragg peak
-    # monitor is mounted on it) makes ``ltotal`` depend on 'time'. The instrument angle
-    # is the only dynamic parameter, so ``group_by_rotation`` has already turned that
-    # same 'time' dimension into 'a4'. Rename to match, or the broadcast below rejects
-    # ``ltotal`` as having a dimension the data does not.
-    if 'time' in ltotal.dims and 'time' not in sample_data.dims:
-        ltotal = ltotal.rename_dims(time='a4')
     return reduce_unwrap.to_wavelength.detector_wavelength_data(
         detector_data=RawDetector[RunType](sample_data),
         lookup=lookup,
@@ -47,4 +73,4 @@ def detector_wavelength_data(
     )
 
 
-providers = (detector_wavelength_data,)
+providers = (detector_ltotal, detector_wavelength_data)

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/workflow.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/workflow.py
@@ -11,6 +11,7 @@ from ess.spectroscopy.types import (
 )
 
 from ess.reduce import unwrap as reduce_unwrap
+from ess.reduce.nexus.types import NeXusName
 
 from ..cutting import group_by_rotation
 from ..io import nexus
@@ -30,7 +31,7 @@ _PROVIDERS = (
 _SIMULATION_PROVIDERS = (
     *nexus.providers,
     *conversion.providers,
-    *detector.providers,
+    *detector.simulation_providers,
     *q_map.providers,
     *time_of_flight.providers,
     convert_simulated_time_to_event_time_offset,
@@ -45,6 +46,12 @@ def BifrostBraggPeakMonitorWorkflow() -> sciline.Pipeline:
     )
     # Use the vanilla implementation instead of the indirect geometry one:
     workflow.insert(reduce_unwrap.to_wavelength.detector_wavelength_data)
+    # The Bragg peak monitor sees the direct beam, so its flight path is a straight
+    # line rather than the analyzer-folded path of the inelastic detectors.
+    workflow.insert(
+        reduce_unwrap.to_wavelength.detector_ltotal_from_straight_line_approximation
+    )
+    workflow[NeXusName[ElasticMonitor]] = 'elastic_monitor'
     for provider in _PROVIDERS:
         workflow.insert(provider)
     for key, val in default_parameters().items():
@@ -59,6 +66,12 @@ def BifrostSimulationBraggPeakMonitorWorkflow() -> sciline.Pipeline:
     )
     # Use the vanilla implementation instead of the indirect geometry one:
     workflow.insert(reduce_unwrap.to_wavelength.detector_wavelength_data)
+    # The Bragg peak monitor sees the direct beam, so its flight path is a straight
+    # line rather than the analyzer-folded path of the inelastic detectors.
+    workflow.insert(
+        reduce_unwrap.to_wavelength.detector_ltotal_from_straight_line_approximation
+    )
+    workflow[NeXusName[ElasticMonitor]] = 'elastic_monitor'
     for provider in _SIMULATION_PROVIDERS:
         workflow.insert(provider)
     for key, val in simulation_default_parameters().items():

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/workflow.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/workflow.py
@@ -10,7 +10,6 @@ from ess.spectroscopy.types import (
     SampleRun,
 )
 
-from ess.reduce import unwrap as reduce_unwrap
 from ess.reduce.nexus.types import NeXusName
 
 from ..cutting import group_by_rotation
@@ -44,13 +43,6 @@ def BifrostBraggPeakMonitorWorkflow() -> sciline.Pipeline:
         run_types=(SampleRun,),
         monitor_types=(ElasticMonitor, NormalizationMonitor),
     )
-    # Use the vanilla implementation instead of the indirect geometry one:
-    workflow.insert(reduce_unwrap.to_wavelength.detector_wavelength_data)
-    # The Bragg peak monitor sees the direct beam, so its flight path is a straight
-    # line rather than the analyzer-folded path of the inelastic detectors.
-    workflow.insert(
-        reduce_unwrap.to_wavelength.detector_ltotal_from_straight_line_approximation
-    )
     workflow[NeXusName[ElasticMonitor]] = 'elastic_monitor'
     for provider in _PROVIDERS:
         workflow.insert(provider)
@@ -63,13 +55,6 @@ def BifrostSimulationBraggPeakMonitorWorkflow() -> sciline.Pipeline:
     workflow = TofWorkflow(
         run_types=(SampleRun,),
         monitor_types=(ElasticMonitor, NormalizationMonitor),
-    )
-    # Use the vanilla implementation instead of the indirect geometry one:
-    workflow.insert(reduce_unwrap.to_wavelength.detector_wavelength_data)
-    # The Bragg peak monitor sees the direct beam, so its flight path is a straight
-    # line rather than the analyzer-folded path of the inelastic detectors.
-    workflow.insert(
-        reduce_unwrap.to_wavelength.detector_ltotal_from_straight_line_approximation
     )
     workflow[NeXusName[ElasticMonitor]] = 'elastic_monitor'
     for provider in _SIMULATION_PROVIDERS:


### PR DESCRIPTION
`get_calibrated_bragg_peak_detector` required `NeXusComponent[NXdetector]`, but the Bragg peak monitor is the elastic monitor (cbm5), written as an `NXmonitor` in CODA files, the geometry artifacts and the McStas simulation file alike. Loading therefore raised

```
ValueError: The NeXus group 'elastic_monitor' was expected to be a NXdetector but is a NXmonitor
```

against every real file. Only the user guide worked, by standing a detector triplet in for the monitor.

The monitor's component, transformation and event data now come from `ElasticMonitor`, which the workflow already declares in `monitor_types` — a re-pointing rather than new machinery. A monitor has no pixel offsets, so the position is the transformed origin as in `get_calibrated_monitor`. `Analyzer` is dropped: `get_base_calibrated_detector_bifrost` never reads it, and a monitor in the direct beam has none. The detector stand-in moves to `simulation_providers`, keeping the user guide working.

Assembly likewise uses `assemble_monitor_data`. `assemble_detector_data` groups events by `event_id` onto a `detector_number` grid, and a single-pixel monitor has nothing to group by; what remains is the geometry assignment `assemble_monitor_data` already does. This holds whether or not the events carry an `event_id` — a file-loaded `cbm5_events` group does, constant `1` throughout; a stream may not.

Also fixes a latent defect that is not monitor-specific: `Ltotal` was derived from `EmptyDetector`, a branch of the graph that never sees the grouping, so a time-dependent position left it labelled `time` while `group_by_rotation` had already turned that dimension into `a4`, and the broadcast in `detector_wavelength_data` rejected it. This bites whenever the tank rotates. It stayed hidden because the user guide's stand-in position is static and the inelastic/Q-cut path uses a `detector_wavelength_data` that takes no `ltotal`. `Ltotal` is now computed from the grouped data, so it carries the right dimensions by construction; the user guide's local override, which existed for the same reason, is gone with it.

## Testing

No regression test for the monitor path here — the simulation file's `elastic_monitor` is histogram-mode, so there is no simulated Bragg peak monitor to drive. It is covered end to end in scipp/esslivedata#1236, where streamed monitor events and live rotation readbacks produce a populated (Qpar, Qperp) map over a multi-angle scan. That branch needs this PR, so it is blocked on it.

## Open question

The scientists asked for the map in the laboratory frame, but `project_momentum_transfer` projects `sample_table_momentum_transfer` — the sample-table frame, which is what you want against an expected reciprocal lattice. Worth settling before merge.

