### PR TITLE
[ESSSPECTROSCOPY] Drop the position offsets from the BIFROST providers

### DIFF
--- a/packages/essspectroscopy/src/ess/bifrost/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/detector.py
@@ -11,7 +11,6 @@ import scippnexus as snx
 from ess.spectroscopy.indirect.conversion import add_spectrometer_coords
 from ess.spectroscopy.types import (
     Analyzer,
-    DetectorPositionOffset,
     EmptyDetector,
     NeXusComponent,
     NeXusTransformation,
@@ -86,7 +85,6 @@ def get_calibrated_detector_bifrost(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
     primary_graph: PrimarySpecCoordTransformGraph[RunType],
     secondary_graph: SecondarySpecCoordTransformGraph[RunType],
 ) -> EmptyDetector[RunType]:
@@ -107,8 +105,6 @@ def get_calibrated_detector_bifrost(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
     primary_graph:
         Coordinate transformation graph for the primary spectrometer.
     secondary_graph:
@@ -122,9 +118,7 @@ def get_calibrated_detector_bifrost(
         Detector geometry and spectrometer coordinates.
     """
 
-    da = get_base_calibrated_detector_bifrost(
-        detector, analyzer, transform=transform, offset=offset
-    )
+    da = get_base_calibrated_detector_bifrost(detector, analyzer, transform=transform)
     da = da.rename(dim_0='tube', dim_1='length')
 
     arc, channel = arc_and_channel_from_detector_number(da.coords['detector_number'])
@@ -147,7 +141,6 @@ def get_base_calibrated_detector_bifrost(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
 ) -> sc.DataArray:
     """Extract the data array corresponding to a detector's signal field.
 
@@ -163,8 +156,6 @@ def get_base_calibrated_detector_bifrost(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
 
     Returns
     -------
@@ -173,9 +164,14 @@ def get_base_calibrated_detector_bifrost(
     """
 
     from ess.reduce.nexus import compute_detector_position, extract_signal_data_array
+    from ess.reduce.nexus.workflow import no_offset
 
     da = extract_signal_data_array(detector)
-    position = compute_detector_position(da, transform=transform, offset=offset)
+    # BIFROST's detectors ride the rotating tank, so a lab-frame offset added after
+    # the transform cannot express any correction one would actually want; the
+    # transformation chain is the handle. compute_detector_position requires the
+    # argument, so pin it to zero here.
+    position = compute_detector_position(da, transform=transform, offset=no_offset)
     return _assign_detector_position(da, position)
 
 

--- a/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
+++ b/packages/essspectroscopy/src/ess/bifrost/single_crystal/detector.py
@@ -7,7 +7,6 @@ import scipp as sc
 import scippnexus as snx
 from ess.spectroscopy.types import (
     Analyzer,
-    DetectorPositionOffset,
     ElasticMonitor,
     EmptyDetector,
     NeXusComponent,
@@ -17,8 +16,6 @@ from ess.spectroscopy.types import (
     RunType,
 )
 
-from ess.reduce.nexus.types import MonitorPositionOffset
-
 from ..detector import _assign_detector_position, get_base_calibrated_detector_bifrost
 
 
@@ -26,7 +23,6 @@ def get_calibrated_bragg_peak_monitor(
     monitor: NeXusComponent[ElasticMonitor, RunType],
     *,
     transform: NeXusTransformation[ElasticMonitor, RunType],
-    offset: MonitorPositionOffset[RunType, ElasticMonitor],
 ) -> EmptyDetector[RunType]:
     """Extract the data array corresponding to the Bragg peak monitor's signal field.
 
@@ -43,8 +39,6 @@ def get_calibrated_bragg_peak_monitor(
         Loaded NeXus monitor.
     transform:
         Transformation that determines the monitor position.
-    offset:
-        Offset to add to the monitor position.
 
     Returns
     -------
@@ -55,9 +49,7 @@ def get_calibrated_bragg_peak_monitor(
 
     da = extract_signal_data_array(monitor)
     unit = transform.value.unit
-    position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit) + offset.to(
-        unit=unit
-    )
+    position = transform.value * sc.vector([0.0, 0.0, 0.0], unit=unit)
     return EmptyDetector[RunType](_assign_detector_position(da, position))
 
 
@@ -96,7 +88,6 @@ def get_calibrated_bragg_peak_detector(
     analyzer: Analyzer[RunType],
     *,
     transform: NeXusTransformation[snx.NXdetector, RunType],
-    offset: DetectorPositionOffset[RunType],
 ) -> EmptyDetector[RunType]:
     """Extract the data array corresponding to a detector's signal field.
 
@@ -112,17 +103,13 @@ def get_calibrated_bragg_peak_detector(
         Loaded analyzer parameters.
     transform:
         Transformation that determines the detector position.
-    offset:
-        Offset to add to the detector position.
 
     Returns
     -------
     :
         Detector with geometry coordinates.
     """
-    return get_base_calibrated_detector_bifrost(
-        detector, analyzer, transform=transform, offset=offset
-    )
+    return get_base_calibrated_detector_bifrost(detector, analyzer, transform=transform)
 
 
 providers = (get_calibrated_bragg_peak_monitor, assemble_bragg_peak_monitor_data)


### PR DESCRIPTION
`DetectorPositionOffset` and `MonitorPositionOffset` are dead knobs in the BIFROST providers: both default to a zero vector, and nothing in essspectroscopy or esslivedata ever sets one.

They are also the wrong shape for this instrument. Both are added *after* the transform, so they are lab-frame constants, while every component they apply to rides the rotating detector tank. The correction one would actually want — "this sits a few mm off along its own axis" — is local-frame and belongs in the transformation chain, which is already the handle used for the tank angle. A fixed lab vector instead translates the whole swept arc rigidly.

essreduce says much the same where `compute_detector_position` is defined: the offset is "mainly used for handling files from other facilities and it is not clear if it is needed for ESS data and should be kept at all".

`compute_detector_position` still requires the argument, so it is pinned to `no_offset` at that one call rather than threaded through four signatures. The monitor provider drops the term outright.

Stacked on #698.

## Testing

Positions are unchanged: the BIFROST Bragg peak Q-map in scipp/esslivedata#1236 produces a bit-identical map over a multi-angle rotation scan.
