### PR TITLE
[ESSSPECTROSCOPY] deps: bump essreduce

### DIFF
--- a/packages/essspectroscopy/pyproject.toml
+++ b/packages/essspectroscopy/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.11"
 dependencies = [
     "dask>=2022.1.0",
     "graphviz>=0.20",
-    "essreduce>=26.6.0",
+    "essreduce>=26.8.0",
     "pandas>=2.1.2",
     "tof>=25.11.0",
 ]


### PR DESCRIPTION
Fixes #708

But requires `pixi lock` before merge, and `pixi lock` requires `essreduce/26.8.0` on conda-forge.