### PR TITLE
[ESSREFLECTOMETRY] fix: correct freia detector dimensions

### DIFF
--- a/packages/essreflectometry/src/ess/freia/beamline.py
+++ b/packages/essreflectometry/src/ess/freia/beamline.py
@@ -7,7 +7,7 @@ from ess.reflectometry.types import ReferenceRun, SampleRun
 DETECTOR_BANK_SIZES = {
     "multiblade_detector": {
         "strip": 64,
-        "blade": 48,
+        "blade": 32,
         "wire": 32,
     },
 }


### PR DESCRIPTION
This was originally just copied from estia, but now I think the values are correct in the coda files, so this error was caught in the integration tests.